### PR TITLE
Laurl override

### DIFF
--- a/media/create_media.py
+++ b/media/create_media.py
@@ -171,6 +171,8 @@ class DashMediaCreator(object):
             "-t", str(self.options.duration),
             "-threads", "0",
         ]
+        if self.options.framerate:
+            ffmpeg_args += ["-r", str(self.options.framerate)]
         if first:
             ffmpeg_args += [
 	        "-codec:a:0", "aac",
@@ -392,8 +394,8 @@ class DashMediaCreator(object):
         # MP4Box does not appear to be able to encrypt and fragment in one
         # stage, so first encrypt the media and then fragment it afterwards
         args = ["MP4Box", "-crypt", xmlfile, "-out", moov_filename]
-        if fps:
-            args += ["-fps", str(fps)]
+        if self.options.framerate:
+            args += ["-fps", str(self.options.framerate)]
         args.append(source)
         print(args)
         rv = subprocess.check_call(args)

--- a/media/create_media.py
+++ b/media/create_media.py
@@ -116,7 +116,7 @@ class DashMediaCreator(object):
             aspect = float(n) / float(d)
         else:
             aspect = float(self.options.aspect)
-        height = int(float(height) / aspect)
+        height = 4 * (int(float(height) / aspect) // 4)
         print "{}: {}x{} {}Kbps".format(dest, width, height, bitrate)
         profile="baseline"
         cbr=(bitrate *10) // 12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Jinja2==2.11.3
 MarkupSafe==1.1.1
-pycrypto==2.6.1
+pycryptodome==3.14.1
 WebTest==2.0.33
 beautifulsoup4==4.8.0
 bitstring==3.1.6

--- a/src/drm.py
+++ b/src/drm.py
@@ -257,7 +257,7 @@ class PlayReady(object):
                 record['PlayReadyHeader'] = prh.decode('utf-16')
                 record['xml'] = ElementTree.parse(StringIO.StringIO(record['PlayReadyHeader']))
             objects.append(record)
-        return record
+        return objects
 
     def generate_pssh(self, representation, keys):
         """Generate a PlayReady Object (PRO) inside a PSSH box"""

--- a/templates/index.html
+++ b/templates/index.html
@@ -197,8 +197,18 @@
             be given the &quot;main&quot; role (AAC, E-AC3 or ID of stream)</td>
                 <td>&check;</td><td>&cross;</td><td>&cross;</td>
             </tr>
+            <tr>
+              <td>marlin_la_url=&lt;escaped-url&gt;</td>
+              <td>Override the Marlin S-URL field for this stream</td>
+              <td>&check;</td><td>&cross;</td><td>&cross;</td>
+            </tr>
             <tr><td>mup=&lt;number&gt;</td><td>Specify minimumUpdatePeriod (in seconds) or -1 to disable updates</td>
                 <td>&check;</td><td>&cross;</td><td>&cross;</td>
+            </tr>
+            <tr>
+              <td>playready_la_url=&lt;escaped-url&gt;</td>
+              <td>Override the PlayReady LA_URL field for this stream</td>
+              <td>&check;</td><td>&check;</td><td>&cross;</td>
             </tr>
             <tr><td>start=(today|epoch|now|iso-datetime)</td><td>Specify
                 availabilityStartTime as "today", "now", "epoch" or an

--- a/tests/drm_test.py
+++ b/tests/drm_test.py
@@ -141,7 +141,7 @@ class PlayreadyTests(unittest.TestCase):
         representation = Representation(id='V1', default_kid=self.keys.keys()[0])
         mspr.generate_checksum = lambda keypair: binascii.a2b_base64('Xy6jKG4PJSY=')
         e_pro = PlayReady.parse_pro(utils.BufferedReader(None, data=base64.b64decode(self.expected_pro)))
-        xml = e_pro['xml']
+        xml = e_pro[0]['xml']
         self.assertEqual(xml.getroot().get("version"),
                          '{:02.1f}.0.0'.format(mspr.version))
         algid = xml.findall('./prh:DATA/prh:PROTECTINFO/prh:ALGID', self.namespaces)
@@ -180,15 +180,17 @@ class PlayreadyTests(unittest.TestCase):
         self.assertEqual(atoms[0].system_id, PlayReady.RAW_SYSTEM_ID)
         self.assertEqual(atoms[0].data.encode('hex'), expected_pro.encode('hex'))
         actual_pro = mspr.parse_pro(utils.BufferedReader(None, data=atoms[0].data))
-        self.assertEqual(actual_pro['xml'].getroot().get("version"),
+        self.assertEqual(actual_pro[0]['xml'].getroot().get("version"),
                          '{:02.1f}.0.0'.format(mspr.version))
-        algid = actual_pro['xml'].findall('./prh:DATA/prh:PROTECTINFO/prh:ALGID', self.namespaces)
+        algid = actual_pro[0]['xml'].findall('./prh:DATA/prh:PROTECTINFO/prh:ALGID',
+                                             self.namespaces)
         self.assertEqual(len(algid), 1)
         self.assertEqual(algid[0].text, "AESCTR")
-        keylen = actual_pro['xml'].findall('./prh:DATA/prh:PROTECTINFO/prh:KEYLEN', self.namespaces)
+        keylen = actual_pro[0]['xml'].findall('./prh:DATA/prh:PROTECTINFO/prh:KEYLEN',
+                                              self.namespaces)
         self.assertEqual(len(keylen), 1)
         self.assertEqual(keylen[0].text, "16")
-        kid = actual_pro['xml'].findall('./prh:DATA/prh:KID', self.namespaces)
+        kid = actual_pro[0]['xml'].findall('./prh:DATA/prh:KID', self.namespaces)
         self.assertEqual(len(kid), 1)
         guid = PlayReady.hex_to_le_guid(self.keys.keys()[0], raw=False)
         self.assertEqual(base64.b64decode(kid[0].text).encode('hex'), guid.replace('-',''))
@@ -212,9 +214,9 @@ class PlayreadyTests(unittest.TestCase):
             print atoms[0].key_ids
         self.assertEqual(atoms[0].system_id, PlayReady.RAW_SYSTEM_ID)
         actual_pro = mspr.parse_pro(utils.BufferedReader(None, data=atoms[0].data))
-        self.assertEqual(actual_pro['xml'].getroot().get("version"),
+        self.assertEqual(actual_pro[0]['xml'].getroot().get("version"),
                          '{:02.1f}.0.0'.format(mspr.version))
-        kid = actual_pro['xml'].findall('./prh:DATA/prh:PROTECTINFO/prh:KID', self.namespaces)
+        kid = actual_pro[0]['xml'].findall('./prh:DATA/prh:PROTECTINFO/prh:KID', self.namespaces)
         self.assertEqual(len(kid), 1)
         self.assertEqual(kid[0].get("ALGID"), "AESCTR")
         self.assertEqual(kid[0].get("CHECKSUM"), 'Xy6jKG4PJSY=')
@@ -241,10 +243,10 @@ class PlayreadyTests(unittest.TestCase):
         self.assertEqual(len(atoms[0].key_ids), len(keys))
         self.assertEqual(atoms[0].system_id, PlayReady.RAW_SYSTEM_ID)
         actual_pro = mspr.parse_pro(utils.BufferedReader(None, data=atoms[0].data))
-        self.assertEqual(actual_pro['xml'].getroot().get("version"),
+        self.assertEqual(actual_pro[0]['xml'].getroot().get("version"),
                          '{:02.1f}.0.0'.format(mspr.version))
-        kids = actual_pro['xml'].findall('./prh:DATA/prh:PROTECTINFO/prh:KIDS/prh:KID',
-                                         self.namespaces)
+        kids = actual_pro[0]['xml'].findall('./prh:DATA/prh:PROTECTINFO/prh:KIDS/prh:KID',
+                                            self.namespaces)
         guid_map = {}
         for keypair in keys.values():
             guid = PlayReady.hex_to_le_guid(keypair.KID.raw, raw=True)

--- a/tests/views_test.py
+++ b/tests/views_test.py
@@ -522,7 +522,7 @@ class TestHandlers(GAETestCase):
                 drm_options = o[1]
                 break
         self.assertIsNotNone(drm_options)
-        pr = drm.PlayReady(self.templates)
+        # pr = drm.PlayReady(self.templates)
         media_files = models.MediaFile.all()
         self.assertGreaterThan(len(media_files), 0)
         total_tests = len(drm_options)
@@ -588,7 +588,56 @@ class TestHandlers(GAETestCase):
     def test_request_unknown_media(self):
         url = self.from_uri("dash-media", mode="vod", filename="notfound", segment_num=1, ext="mp4")
         response = self.app.get(url, status=404)
-
+        
+    def test_playready_la_url(self):
+        """
+        PlayReady LA_URL in the manifest
+        """
+        # TODO: don't hard code KID
+        test_la_url = drm.PlayReady.TEST_LA_URL.format(
+            cfgs='(kid:QFS0GixTmUOU3Fxa2VhLrA==,persist:false,sl:150)')
+        self.check_playready_la_url_value(test_la_url, [])
+        
+    def test_playready_la_url_override(self):
+        """
+        Replace LA_URL in stream with CGI playready_la_url parameter
+        """
+        test_la_url = 'https://licence.url.override/'
+        self.check_playready_la_url_value(
+            test_la_url,
+            ['playready_la_url={0}'.format(urllib.quote_plus(test_la_url))])
+        
+    def check_playready_la_url_value(self, test_la_url, args):
+        """
+        Check the LA_URL in the PRO element is correct
+        """
+        self.setup_media()
+        self.logoutCurrentUser()
+        filename = 'hand_made.mpd'
+        manifest = manifests.manifest[filename]
+        baseurl = self.from_uri('dash-mpd-v2', manifest=filename, stream='bbb')
+        args += ['mode=vod', 'drm=playready']
+        baseurl += '?' + '&'.join(args)
+        response = self.app.get(baseurl)
+        mpd = ViewsTestDashValidator(self.app, 'vod', response.xml, baseurl)
+        mpd.validate()
+        self.assertEqual(len(mpd.manifest.periods), 1)
+        schemeIdUri = "urn:uuid:" + drm.PlayReady.SYSTEM_ID.upper()
+        pro_tag = "{{{0}}}pro".format(mpd.xmlNamespaces['mspr'])
+        for adap_set in mpd.manifest.periods[0].adaptation_sets:
+            for prot in adap_set.contentProtection:
+                if prot.schemeIdUri != schemeIdUri:
+                    continue
+                for elt in prot.children:
+                    if elt.tag != pro_tag:
+                        continue
+                    pro = base64.b64decode(elt.text)
+                    for record in drm.PlayReady.parse_pro(utils.BufferedReader(None, data=pro)):
+                        la_urls = record['xml'].findall(
+                            './prh:DATA/prh:LA_URL', mpd.xmlNamespaces)
+                        self.assertEqual(len(la_urls), 1)
+                        self.assertEqual(la_urls[0].text, test_la_url)
+        
     def test_injected_http_error_codes(self):
         self.setup_media()
         self.logoutCurrentUser()


### PR DESCRIPTION
In some test situations, it is useful to be able to override the LA_URL specified in the stream settings. This PR adds support for overriding the license URL for both Marlin and PlayReady licenses.