### PR TITLE
allow CORS domains to be configured from settings.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ A settings.py needs to be created that contains
 
     from utils import on_production_server
 
-    cookie_secret='arandomstring'
+    cookie_secret = 'arandomstring'
     csrf_secret = 'arandomstring'
-    DEBUG=not on_production_server
+    DEBUG = not on_production_server
+    allowed_domains = "*"
 
 The cookie_secret and csrf_secret variables need to contain a randomly
 generated block of ascii characters. There is a gen_settings.py script
 that can be used to auto-generate settings.py
+
+The `allowed_domains` setting is optional. If it is missing, a default
+list of domains that supports common JavaScript DASH libraries will be
+used. An `allowed_domains` value of "*" tells the server to allow any
+request from any domain.
 
 ### Running development server directly on the host machine
 Install the Python 2 Google App Engine (GAE)

--- a/gen-settings.py
+++ b/gen-settings.py
@@ -6,6 +6,7 @@ TEMPLATE="""from utils import on_production_server
 cookie_secret = r'{cookie}'
 csrf_secret = r'{csrf}'
 DEBUG = not on_production_server
+allowed_domains = "*"
 """
 
 cookie = []


### PR DESCRIPTION
Rather than hard-coding the list of allowed domains for CORS requests, allow settings.py to specify the allowed list of
domains in an allowed_domains variable. This can either be a compiled regex or a string.