### PR TITLE
allow appserver log level to be configured

### DIFF
--- a/runserver.sh
+++ b/runserver.sh
@@ -8,10 +8,13 @@ fi
 if [ -z "${PORT}" ]; then
     PORT=9080
 fi
+if [ -z "${LOG_LEVEL}" ]; then
+    LOG_LEVEL="info"
+fi
 let ADMIN_PORT=$(( $PORT + 1))
 HOST_CHECKING=""
 if dev_appserver.py -h | grep -q enable_host_checking ; then
   HOST_CHECKING="--enable_host_checking False"
 fi
 python -m lesscpy static/css -o static/css/
-exec dev_appserver.py --port=${PORT} --host=0.0.0.0  --admin_host=0.0.0.0 --admin_port=${ADMIN_PORT} --storage_path=${GAEDATA} --dev_appserver_log_level=info ${HOST_CHECKING} app.yaml 
+exec dev_appserver.py --port=${PORT} --host=0.0.0.0  --admin_host=0.0.0.0 --admin_port=${ADMIN_PORT} --storage_path=${GAEDATA} --dev_appserver_log_level=${LOG_LEVEL} ${HOST_CHECKING} app.yaml

--- a/sdk-dockerfile
+++ b/sdk-dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:18.04
 EXPOSE 9080 9081
 ENV HOME=/home/dash
 ENV GAEDATA=/home/dash/.gaedata
+ENV LOG_LEVEL="info"
 RUN apt-get update && \
     apt-get -y -q --force-yes install \
     python2.7 \


### PR DESCRIPTION
When using runserver.sh to start the app, it might be useful to be able to modify the logging level. This commit adds a LOG_LEVEL to the runserver.sh script and the Docker container that uses this script.