### PR TITLE
Add support for MPD patches

### DIFF
--- a/dashlive/mpeg/dash/patch_location.py
+++ b/dashlive/mpeg/dash/patch_location.py
@@ -1,0 +1,28 @@
+#############################################################################
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
+
+
+from typing import NamedTuple
+
+class PatchLocation(NamedTuple):
+    ttl: int
+    location: str

--- a/dashlive/mpeg/dash/period.py
+++ b/dashlive/mpeg/dash/period.py
@@ -21,6 +21,7 @@
 #############################################################################
 
 import datetime
+from typing import Any, ClassVar
 
 from dashlive.utils.list_of import ListOf
 from dashlive.utils.object_with_fields import ObjectWithFields
@@ -31,12 +32,15 @@ class Period(ObjectWithFields):
     """
     Class used to hold data about one Period
     """
+    id: str
+    adaptationSets: list[AdaptationSet]
+    start: datetime.timedelta
 
-    OBJECT_FIELDS = {
+    OBJECT_FIELDS: ClassVar[dict[str, Any]] = {
         'adaptationSets': ListOf(AdaptationSet),
         'start': datetime.timedelta,
     }
-    DEFAULT_VALUES = {
+    DEFAULT_VALUES: ClassVar[dict[str, Any]] = {
         'start': datetime.timedelta(0),
         'id': 'p0',
     }

--- a/dashlive/mpeg/dash/timing.py
+++ b/dashlive/mpeg/dash/timing.py
@@ -131,6 +131,14 @@ class DashTiming:
             seconds=self.timeShiftBufferDepth)
         if options.leeway is not None:
             self.leeway = datetime.timedelta(seconds=options.leeway)
+        if self.minimumUpdatePeriod is not None:
+            num_refreshes = int(
+                self.elapsedTime.total_seconds() // self.minimumUpdatePeriod)
+            self.publishTime = (
+                self.availabilityStartTime +
+                datetime.timedelta(seconds=(
+                    num_refreshes * self.minimumUpdatePeriod)))
+            self.publishTime = self.publishTime.replace(microsecond=0)
 
     def generate_manifest_context(self):
         if self.mode == 'live':

--- a/dashlive/mpeg/dash/validator/adaptation_set.py
+++ b/dashlive/mpeg/dash/validator/adaptation_set.py
@@ -46,7 +46,7 @@ class AdaptationSet(RepresentationBaseType):
     async def prefetch_media_info(self) -> bool:
         self.progress.add_todo(len(self.representations))
         futures = {
-            rep.generate_segment_todo_list() for rep in self.representations}
+            rep.prefetch_media_info() for rep in self.representations}
         results = await asyncio.gather(*futures)
         self.progress.inc()
         return False not in results
@@ -98,11 +98,16 @@ class AdaptationSet(RepresentationBaseType):
         if (
                 self.target_duration is not None and
                 self.target_duration.total_seconds() == 0):
+            self.log.debug('AdaptationSet %d finished (total_seconds==0)',
+                           self.id)
             return True
         for child in self.representations:
             if not child.finished():
-                self.log.debug('representation %s not finished', child.id)
+                self.log.debug(
+                    'Representation %s in AdaptationSet %d not finished',
+                    child.id, self.id)
                 return False
+        self.log.debug('AdaptationSet %d finished', self.id)
         return True
 
     def set_representation_info(self, info: ServerRepresentation):

--- a/dashlive/mpeg/dash/validator/dash_element.py
+++ b/dashlive/mpeg/dash/validator/dash_element.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
-from typing import Optional
+from typing import Any, ClassVar, Optional
 import urllib.parse
 
 from lxml import etree as ET
@@ -22,7 +22,7 @@ from .options import ValidatorOptions
 from .progress import NullProgress
 
 class ContextAdapter(logging.LoggerAdapter):
-    def process(self, msg: str, kwargs) -> tuple[str, dict]:
+    def process(self, msg: str, kwargs: dict) -> tuple[str, dict]:
         # url = getattr(self.extra, "url", None)
         # if url is not None and 'http' not in msg:
         #    return (f'{msg}\n    "{url}"\n', kwargs,)
@@ -43,7 +43,7 @@ class DashElement(ABC):
         'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
     }
 
-    attributes = []
+    attributes: ClassVar[list[tuple[str, Any, Any]]] = []
 
     def __init__(self,
                  elt: ET.ElementBase,
@@ -137,6 +137,12 @@ class DashElement(ABC):
         for child in self.children():
             result += child.get_errors()
         return result
+
+    def reset_errors(self) -> None:
+        self.attrs.reset()
+        self.elt.reset()
+        for child in self.children():
+            child.reset_errors()
 
     @abstractmethod
     def children(self) -> list["DashElement"]:

--- a/dashlive/mpeg/dash/validator/dash_element.py
+++ b/dashlive/mpeg/dash/validator/dash_element.py
@@ -204,15 +204,10 @@ class DashElement(ABC):
             else:
                 ns_sel.append(f'dash:{part}')
         sel = '/'.join(ns_sel)
-        match = cls.INDEX_RE.search(sel)
-        if match:
-            sel = sel[:match.start('index') - 1]
-        xml = xml.xpath(sel, namespaces=cls.xmlNamespaces)
-        if xml and match:
-            return [xml[int(match['index'])]]
-        if isinstance(xml, str):
-            return [xml]
-        return xml
+        result = xml.xpath(sel, namespaces=cls.xmlNamespaces)
+        if isinstance(result, str):
+            return [result]
+        return result
 
     @classmethod
     def init_xml_namespaces(clz) -> None:

--- a/dashlive/mpeg/dash/validator/dash_element.py
+++ b/dashlive/mpeg/dash/validator/dash_element.py
@@ -184,6 +184,30 @@ class DashElement(ABC):
         return None
 
     @classmethod
+    def xpath(cls, xml: ET.ElementBase, path: str) -> list[ET.ElementBase | str]:
+        """
+        Find an element using XPath. In addition to the XPath features of
+        lxml, this function also supports using the DASH namespace for
+        any selector that doesn't specify a namespace.
+        """
+        ns_sel = []
+        for part in path.split('/'):
+            if part == '' or part[0] == '@' or ':' in part:
+                ns_sel.append(part)
+            else:
+                ns_sel.append(f'dash:{part}')
+        sel = '/'.join(ns_sel)
+        match = cls.INDEX_RE.search(sel)
+        if match:
+            sel = sel[:match.start('index') - 1]
+        xml = xml.xpath(sel, namespaces=cls.xmlNamespaces)
+        if xml and match:
+            return [xml[int(match['index'])]]
+        if isinstance(xml, str):
+            return [xml]
+        return xml
+
+    @classmethod
     def init_xml_namespaces(clz) -> None:
         for prefix, url in clz.xmlNamespaces.items():
             ET.register_namespace(prefix, url)

--- a/dashlive/mpeg/dash/validator/dash_element.py
+++ b/dashlive/mpeg/dash/validator/dash_element.py
@@ -33,13 +33,14 @@ class DashElement(ABC):
     class Parent:
         pass
 
-    xmlNamespaces = {
+    xmlNamespaces: ClassVar[dict[str, str]] = {
         'cenc': 'urn:mpeg:cenc:2013',
         'dash': 'urn:mpeg:dash:schema:mpd:2011',
         'mspr': 'urn:microsoft:playready',
+        'patch': 'urn:mpeg:dash:schema:mpd-patch:2020',
+        'prh': 'http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader',
         'scte35': "http://www.scte.org/schemas/35/2016",
         'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-        'prh': 'http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader',
     }
 
     attributes = []

--- a/dashlive/mpeg/dash/validator/patch.py
+++ b/dashlive/mpeg/dash/validator/patch.py
@@ -1,0 +1,121 @@
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
+
+from typing import Any, ClassVar
+
+from lxml import etree as ET
+
+from dashlive.utils.date_time import from_isodatetime
+
+from .dash_element import DashElement
+
+class Change(DashElement):
+    attributes: ClassVar[list[tuple[str, Any, Any]]] = [
+        ('sel', str, None),
+    ]
+
+    patch_type: str
+    sel: str
+
+    def __init__(self,
+                 xml: ET.ElementBase,
+                 parent: DashElement) -> None:
+        super().__init__(xml, parent)
+        prefix = f'{{{self.xmlNamespaces["patch"]}}}'
+        self.patch_type = xml.tag
+        if self.patch_type.startswith(prefix):
+            self.patch_type = xml.tag[len(prefix):]
+
+    def children(self) -> list[DashElement]:
+        return []
+
+    def validate(self) -> None:
+        self.elt.check_includes(
+            ['add', 'replace', 'remove'],
+            self.patch_type,
+            msg=f'Unexpected Patch element {self.patch_type}',
+            clause='5.15.3')
+        if not self.attrs.check_not_none(
+                self.sel,
+                'sel attribute is mandatory', clause='5.15.3.4'):
+            return
+        xml = self.mpd.parent.xml
+        target = self.xpath(xml, self.sel)
+        if target is None or len(target) == 0:
+            self.attrs.add_error(
+                f'Failed to find manifest node "{self.sel}"')
+            return
+        self.attrs.check_equal(
+            len(target), 1,
+            msg='XPath must only select a single node',
+            clause='5.15.3.4')
+
+
+class Patch(DashElement):
+    attributes: ClassVar[list[tuple[str, Any, Any]]] = [
+        ('mpdId', str, None),
+        ('originalPublishTime', from_isodatetime, None),
+        ('publishTime', from_isodatetime, None),
+    ]
+
+    changes: list[Change]
+    xml_text: list[str]
+    url: str
+
+    def __init__(self,
+                 xml: ET.ElementBase,
+                 parent: DashElement,
+                 url: str,
+                 xml_text: list[str]) -> None:
+        super().__init__(xml, parent)
+        self.url = url
+        self.xml_text = xml_text
+        self.changes = [Change(elt, self) for elt in xml]
+        tag = f'{{{self.xmlNamespaces["patch"]}}}Patch'
+        self.elt.check_equal(
+            xml.tag, tag,
+            msg=f'must have a Patch element as toplevel element not {xml.tag}')
+
+    def children(self) -> list[DashElement]:
+        return self.changes
+
+    def print_patch_text(self) -> None:
+        print(f'=== {self.url} ===')
+        for idx, line in enumerate(self.xml_text, start=1):
+            print(f'{idx:03d}: {line}')
+
+    def validate(self) -> None:
+        self.attrs.check_not_none(
+            self.mpdId,
+            msg='Patch@mpdId is a mandatory attribute',
+            clause='5.15.3.2')
+        self.attrs.check_equal(
+            self.mpdId,
+            self.mpd.id,
+            msg='Patch@mpdId must match MPD@id',
+            clause='5.15.5')
+        self.attrs.check_not_none(
+            self.publishTime,
+            msg='Patch@publishTime is a mandatory attribute',
+            clause='5.15.3.2')
+        self.attrs.check_not_none(
+            self.originalPublishTime,
+            msg='Patch@originalPublishTime is a mandatory attribute',
+            clause='5.15.3.2')
+        self.attrs.check_equal(
+            self.originalPublishTime,
+            self.mpd.publishTime,
+            msg='Patch@originalPublishTime must match MPD@publishTime',
+            clause='5.15.5')
+        self.attrs.check_greater_than(
+            self.publishTime,
+            self.originalPublishTime,
+            msg='publishTime must be greater than originalPublishTime',
+            clause='5.15.5')
+        for child in self.changes:
+            child.validate()

--- a/dashlive/mpeg/dash/validator/patch_location.py
+++ b/dashlive/mpeg/dash/validator/patch_location.py
@@ -51,8 +51,12 @@ class PatchLocation(DashElement):
                     parsed.scheme.lower(),
                     msg=f'Expected HTTP or HTTPS for Patch URL, got "{self.url}"'):
                 return
-            now = self.mpd.now()
-            if now > self.mpd.publishTime and self.patch is None:
+            mpd = self.mpd
+            elapsed = mpd.now() - mpd.publishTime
+            if (
+                    self.patch is None and
+                    mpd.minimumUpdatePeriod is not None and
+                    elapsed >= mpd.minimumUpdatePeriod):
                 if not await self.load():
                     self.elt.add_error('Failed to load patch')
                     return

--- a/dashlive/mpeg/dash/validator/patch_location.py
+++ b/dashlive/mpeg/dash/validator/patch_location.py
@@ -1,0 +1,116 @@
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
+
+import io
+from typing import Any, ClassVar
+import urllib.parse
+
+from lxml import etree as ET
+
+from .dash_element import DashElement
+from .patch import Patch
+from .validation_flag import ValidationFlag
+
+class PatchLocation(DashElement):
+    attributes: ClassVar[list[tuple[str, Any, Any]]] = [
+        ('ttl', int, None),
+    ]
+
+    url: str
+    patch: Patch | None = None
+
+    def __init__(self,
+                 xml: ET.ElementBase,
+                 parent: DashElement | None) -> None:
+        super().__init__(xml, parent)
+        self.url = xml.text
+
+    def children(self) -> list[DashElement]:
+        if self.patch:
+            return [self.patch]
+        return []
+
+    async def validate(self):
+        if ValidationFlag.MANIFEST not in self.options.verify:
+            return
+        self.elt.check_not_none(
+            self.url,
+            'PatchLocation must contain a URL',
+            clause='5.15.2')
+        try:
+            parsed = urllib.parse.urlparse(self.url, scheme='http')
+            self.elt.check_includes(
+                ['http', 'https'],
+                parsed.scheme.lower(),
+                msg=f'Expected HTTP or HTTPS for Patch URL, got "{self.url}"')
+            if not await self.load():
+                self.elt.add_error('Failed to load patch')
+                return
+            self.patch.validate()
+        except ValueError as err:
+            self.elt.add_error(
+                f'Failed to parse PatchLocation URL: {err}',
+                clause='5.15')
+            return
+
+    async def load(self) -> bool:
+        if not self.elt.check_not_none(
+                self.url, msg='URL of PatchLocation is missing'):
+            return False
+        response = await self.http.get(self.url)
+        if not self.elt.check_equal(
+                response.status_code, 200,
+                msg=f'Failed to load patch: {response.status_code}: {self.url}'):
+            return False
+        try:
+            async with self.pool.group() as tg:
+                body = response.get_data(as_text=False)
+                if self.options.save:
+                    tg.submit(self.save, body)
+                tg.submit(self.parse_body, body)
+        except Exception as exc:
+            self.elt.add_error(f'Failed to load patch: {exc}')
+            self.log.error('Failed to load patch: %s', exc)
+            return False
+        return True
+
+    def print_patch_text(self) -> None:
+        if self.patch is not None:
+            self.patch.print_patch_text()
+        else:
+            print(f'== Patch {self.url} has not been fetched ==')
+
+    def save(self, body: bytes) -> None:
+        if self.parent.id:
+            default = f'patch-{self.parent.id}'
+        else:
+            default = 'patch'
+        filename = self.output_filename(
+            default=default, bandwidth=None,
+            prefix=self.options.prefix, elt_id=self.parent.id,
+            makedirs=True)
+        self.log.debug('saving Patch file: %s', filename)
+        with self.open_file(filename, self.options) as dest:
+            dest.write(body)
+
+    def parse_body(self, body: bytes) -> None:
+        parser = ET.XMLParser(remove_blank_text=self.options.pretty)
+        xml = ET.parse(io.BytesIO(body), parser)
+        xml_text: list[str] = []
+        encoding = xml.docinfo.encoding
+        if self.options.pretty:
+            pp_txt = ET.tostring(
+                xml, pretty_print=True, xml_declaration=True,
+                encoding=encoding)
+            xml = ET.parse(io.BytesIO(pp_txt))
+            for line in io.StringIO(str(pp_txt, encoding)):
+                xml_text.append(line.rstrip())
+        else:
+            for line in io.StringIO(str(body, encoding)):
+                xml_text.append(line.rstrip())
+        self.patch = Patch(xml.getroot(), self, self.url, xml_text)

--- a/dashlive/mpeg/dash/validator/period.py
+++ b/dashlive/mpeg/dash/validator/period.py
@@ -88,7 +88,10 @@ class Period(DashElement):
     def finished(self) -> bool:
         for child in self.children():
             if not child.finished():
+                self.log.debug('AdaptationSet %d in period %s not finished',
+                               child.id, self.id)
                 return False
+        self.log.debug('period %s has finished', self.id)
         return True
 
     def get_duration(self) -> datetime.timedelta:

--- a/dashlive/mpeg/dash/validator/validator.py
+++ b/dashlive/mpeg/dash/validator/validator.py
@@ -225,6 +225,10 @@ class DashValidator(DashElement):
             self.save_manifest()
         if self.mode == 'live' and self.prev_manifest is not None:
             self.attrs.check_equal(
+                self.prev_manifest.id, self.manifest.id,
+                template=r'MPD@id has changed from {} to {}',
+                clause='5.4.1')
+            self.attrs.check_equal(
                 self.prev_manifest.availabilityStartTime, self.manifest.availabilityStartTime,
                 template=r'availabilityStartTime has changed from {} to {}')
             age = self.manifest.publishTime - self.prev_manifest.publishTime

--- a/dashlive/server/manifests.py
+++ b/dashlive/server/manifests.py
@@ -23,7 +23,7 @@
 from dataclasses import dataclass, field
 import hashlib
 import logging
-from typing import AbstractSet, Iterator, NamedTuple
+from typing import AbstractSet, Iterator, NamedTuple, Set
 
 from dashlive.mpeg.dash.profiles import primary_profiles
 from dashlive.server.options.drm_options import DrmLocation, DrmSelection
@@ -140,13 +140,15 @@ class DashManifest:
         Returns an list of support DASH options
         """
         drm_opts = self.get_drm_options(mode)
-        exclude = {'abr', 'bugCompatibility', 'drmSelection',
-                   'leeway', 'mode', 'numPeriods', 'minimumUpdatePeriod'}
+        exclude: Set[str] = {
+            'abr', 'bugCompatibility', 'drmSelection',
+            'leeway', 'mode', 'numPeriods', 'minimumUpdatePeriod',
+        }
         exclude.update(set(kwargs.keys()))
         if simplified:
             exclude.update({
                 'availabilityStartTime', 'useBaseUrls', 'playreadyVersion',
-                'playreadyPiff', 'utcMethod', 'clockDrift'})
+                'playreadyPiff', 'utcMethod', 'clockDrift', 'patch'})
         if mode != 'live':
             exclude.update({'clockDrift', 'minimumUpdatePeriod', 'timeShiftBufferDepth'})
         all_options = self.features.union(set(self.restrictions.keys()))
@@ -222,8 +224,9 @@ manifest = {
     'hand_made.mpd': DashManifest(
         title='Hand-made manifest',
         features={
-            'abr', 'audioCodec', 'useBaseUrls', 'drmSelection', 'eventTypes', 'mode',
-            'minimumUpdatePeriod', 'numPeriods', 'segmentTimeline', 'utcMethod'},
+            'abr', 'audioCodec', 'useBaseUrls', 'drmSelection', 'eventTypes',
+            'mode', 'minimumUpdatePeriod', 'numPeriods', 'patch',
+            'segmentTimeline', 'utcMethod'},
     ),
     'manifest_vod_aiv.mpd': DashManifest(
         title='AIV on demand profile',

--- a/dashlive/server/options/manifest_options.py
+++ b/dashlive/server/options/manifest_options.py
@@ -189,6 +189,20 @@ UpdateCount = DashOption(
     cgi_name='update',
     cgi_type='<number>')
 
+UsePatches = DashOption(
+    usage=OptionUsage.MANIFEST,
+    short_name='patch',
+    full_name='patch',
+    title='Use MPD patches',
+    description='Use MPD patches for live streams',
+    from_string=DashOption.bool_from_string,
+    to_string=DashOption.bool_to_string,
+    cgi_name='patch',
+    cgi_choices=(
+        ('No', '0'),
+        ('Yes', '1'),
+    ))
+
 manifest_options = [
     AbrControl,
     AvailabilityStartTime,
@@ -202,5 +216,6 @@ manifest_options = [
     SegmentTimeline,
     TimeshiftBufferDepth,
     UpdateCount,
-    UseBaseUrl
+    UseBaseUrl,
+    UsePatches,
 ]

--- a/dashlive/server/requesthandler/htmlpage.py
+++ b/dashlive/server/requesthandler/htmlpage.py
@@ -231,7 +231,7 @@ class VideoPlayer(HTMLHandlerBase):
         if stream_model is None:
             logging.error('Unknown stream: %s', stream)
             return flask.make_response(f'Unknown stream: {html.escape(stream)}', 404)
-        dash_parms = self.calculate_manifest_params(mpd_url=manifest, options=options)
+        dash_parms = self.calculate_manifest_params(mpd_name=manifest, options=options)
         for item in {'periods', 'period', 'ref_representation', 'audio', 'video'}:
             try:
                 del dash_parms[item]

--- a/dashlive/server/requesthandler/manifest_requests.py
+++ b/dashlive/server/requesthandler/manifest_requests.py
@@ -70,7 +70,8 @@ class ServeManifest(RequestHandlerBase):
                 restrictions=mft.restrictions,
                 features=mft.features)
         except ValueError as e:
-            return flask.make_response(f'Invalid CGI parameters: {e}', 400)
+            logging.info('Invalid CGI parameters: %s', e)
+            return flask.make_response('Invalid CGI parameters', 400)
         if mode != 'live':
             # Patch elements are ignored if MPD@type == 'static'
             options.update(patch=False)
@@ -218,6 +219,7 @@ class ServePatch(RequestHandlerBase):
         except ValueError as e:
             logging.info('Invalid CGI parameters: %s', e)
             return flask.make_response('Invalid CGI parameters', 400)
+
         options.update(patch=True, segmentTimeline=True)
         options.remove_unused_parameters('live')
         original_publish_time = datetime.datetime.fromtimestamp(

--- a/dashlive/server/requesthandler/manifest_requests.py
+++ b/dashlive/server/requesthandler/manifest_requests.py
@@ -21,6 +21,7 @@
 #############################################################################
 
 import datetime
+import html
 import logging
 import math
 import flask
@@ -30,6 +31,7 @@ from dashlive.server import manifests
 from dashlive.server.models import Stream
 from dashlive.server.options.container import OptionsContainer
 from dashlive.utils.objects import dict_to_cgi_params
+from dashlive.utils.timezone import UTC
 
 from .base import RequestHandlerBase
 from .decorators import uses_stream, current_stream
@@ -48,7 +50,8 @@ class ServeManifest(RequestHandlerBase):
             mft = manifests.manifest[manifest]
         except KeyError as err:
             logging.debug('Unknown manifest: %s (%s)', manifest, err)
-            return flask.make_response(f'{manifest} not found', 404)
+            return flask.make_response(
+                f'{html.escape(manifest)} not found', 404)
         try:
             modes = mft.restrictions['mode']
         except KeyError:
@@ -57,7 +60,8 @@ class ServeManifest(RequestHandlerBase):
             logging.debug(
                 'Mode %s not supported with manifest %s (supported=%s)',
                 mode, manifest, modes)
-            return flask.make_response(f'{manifest} not found', 404)
+            return flask.make_response(
+                f'{html.escape(manifest)} not found', 404)
         context = self.create_context(**kwargs)
         context['title'] = current_stream.title
         try:
@@ -67,13 +71,20 @@ class ServeManifest(RequestHandlerBase):
                 features=mft.features)
         except ValueError as e:
             return flask.make_response(f'Invalid CGI parameters: {e}', 400)
+        if mode != 'live':
+            # Patch elements are ignored if MPD@type == 'static'
+            options.update(patch=False)
+        if options.patch and 'segmentTimeline' not in mft.features:
+            return flask.make_response(
+                f'manifest {html.escape(manifest)} does not SegmentTimeline',
+                400)
         if 'segmentTimeline' not in mft.features:
             options.update(segmentTimeline=False)
-        elif mft.segment_timeline:
+        elif mft.segment_timeline or options.patch:
             options.update(segmentTimeline=True)
         options.remove_unused_parameters(mode)
         context['options'] = options
-        dash = self.calculate_manifest_params(mpd_url=manifest, options=options)
+        dash = self.calculate_manifest_params(mpd_name=manifest, options=options)
         context.update(dash)
         response = self.check_for_synthetic_manifest_error(options, context)
         if response is not None:
@@ -149,3 +160,86 @@ class LegacyManifestUrl(ServeManifest):
         except KeyError:
             logging.debug('Unknown manifest: %s', manifest)
             return flask.make_response(f'{manifest} not found', 404)
+
+class ServePatch(RequestHandlerBase):
+    """
+    handler for generating MPD patch files
+    """
+
+    decorators = [uses_stream]
+
+    def get(self,
+            stream: str,
+            manifest: str,
+            publish: int,  # publishTime from Unix epoch
+            **kwargs):
+
+        logging.debug(
+            'ServePatch: stream=%s manifest=%s', stream, manifest)
+        try:
+            mft = manifests.manifest[f'{manifest}.mpd']
+        except KeyError as err:
+            logging.debug('Unknown manifest: %s (%s)', manifest, err)
+            return flask.make_response(
+                f'{html.escape(manifest)} not found', 404)
+
+        if 'patch' not in mft.features:
+            logging.warning(
+                'MPD patches are not supported with manifest %s',
+                manifest)
+            return flask.make_response(
+                f'{html.escape(manifest)} does not support patches', 400)
+
+        if 'segmentTimeline' not in mft.features:
+            logging.warning(
+                'SegmentTimeline are not supported with manifest %s',
+                manifest)
+            return flask.make_response(
+                f'{html.escape(manifest)} does not support SegmentTimeline',
+                400)
+        try:
+            modes = mft.restrictions['mode']
+        except KeyError:
+            modes = primary_profiles.keys()
+        if 'live' not in modes:
+            logging.warning(
+                'Live mode not supported with manifest %s (supported=%s)',
+                manifest, modes)
+            return flask.make_response(
+                f'{html.escape(manifest)} live mode not supported',
+                400)
+
+        context = self.create_context(**kwargs)
+        try:
+            options = self.calculate_options(
+                mode='live', args=flask.request.args, stream=current_stream,
+                restrictions=mft.restrictions,
+                features=mft.features)
+        except ValueError as e:
+            logging.info('Invalid CGI parameters: %s', e)
+            return flask.make_response('Invalid CGI parameters', 400)
+        options.update(patch=True, segmentTimeline=True)
+        options.remove_unused_parameters('live')
+        original_publish_time = datetime.datetime.fromtimestamp(
+            publish, tz=UTC())
+        context.update({
+            'options': options,
+            'original_publish_time': original_publish_time,
+        })
+        dash = self.calculate_manifest_params(
+            mpd_name=f'{manifest}.mpd', options=options)
+        context.update(dash)
+
+        body = flask.render_template(f'patches/{manifest}.xml', **context)
+        try:
+            max_age = int(math.floor(context["minimumUpdatePeriod"]))
+        except KeyError:
+            max_age = 60
+        # MIME type is defined in clause C.5 of DASH specification
+        headers = {
+            'Content-Type': 'application/dash-patch+xml',
+            'Cache-Control': f'max-age={max_age}',
+            'Accept-Ranges': 'none',
+        }
+        self.add_allowed_origins(headers)
+        return flask.make_response((body, 200, headers))

--- a/dashlive/server/routes.py
+++ b/dashlive/server/routes.py
@@ -96,6 +96,10 @@ routes = {
         r'/dash/<regex("(live|vod|odvod)"):mode>/<stream>/<manifest>',
         handler='manifest_requests.ServeManifest',
         title='DASH test stream'),
+    "mpd-patch": Route(
+        r'/patch/<stream>/<manifest>/<int:publish>',
+        handler='manifest_requests.ServePatch',
+        title='DASH manifest patch'),
     "dash-media": Route(
         r'/dash/<regex("(live|vod)"):mode>/<stream>/<filename>/' +
         r'<regex("(\d+|init)"):segment_num>.<regex("(mp4|m4v|m4a|m4s)"):ext>',

--- a/templates/manifests/hand_made.mpd
+++ b/templates/manifests/hand_made.mpd
@@ -4,6 +4,7 @@
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
      publishTime="{{publishTime|isoDateTime}}"
+     id="{{ mpd_id }}"
   {%- if mode=='live' %}
     type="dynamic"
     {%- if minimumUpdatePeriod %}
@@ -28,6 +29,9 @@
  </ProgramInformation>
  <Location>{{request_uri|xmlSafe}}</Location>
  {%- if timeSource %}<UTCTiming schemeIdUri="{{timeSource.method}}" value="{{timeSource.value}}"/>{% endif %}
+ {%- if options.patch %}
+   <PatchLocation ttl="{{ patch.ttl }}">{{ patch.location|xmlSafe }}</PatchLocation>
+ {% endif -%}
  {%- for period in periods %}
    <Period
      start="{{period.start|isoDuration}}"

--- a/templates/patches/hand_made.xml
+++ b/templates/patches/hand_made.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Patch
+    xmlns="urn:mpeg:dash:schema:mpd-patch:2020"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:mpeg:dash:schema:mpd-patch:2020 DASH-MPD-PATCH.xsd"
+    mpdId="{{ mpd_id }}"
+    originalPublishTime="{{ original_publish_time|isoDateTime }}"
+    publishTime="{{ publishTime|isoDateTime }}">
+  <replace sel="/MPD/@publishTime">{{ publishTime|isoDateTime }}</replace>
+  <replace sel="/MPD/PatchLocation[0]">
+    <PatchLocation ttl="{{ patch.ttl }}">{{ patch.location }}</PatchLocation>
+  </replace>
+  {%- for period in periods %}
+    {%- for adp in period.adaptationSets %}
+      {%- if adp.representations %}
+        {%- with rep=adp.representations[0] %}
+  <replace
+      sel="/MPD/Period[@id='{{ period.id }}']/AdaptationSet[@id='{{ adp.id }}']/SegmentTemplate/SegmentTimeline">
+    {% include "segment/timeline.xml" %}
+  </replace>
+        {% endwith -%}
+      {%- endif %}
+    {%- endfor %} {# adaptationSets #}
+  {%- endfor %} {# periods #}
+</Patch>

--- a/templates/patches/hand_made.xml
+++ b/templates/patches/hand_made.xml
@@ -7,7 +7,7 @@
     originalPublishTime="{{ original_publish_time|isoDateTime }}"
     publishTime="{{ publishTime|isoDateTime }}">
   <replace sel="/MPD/@publishTime">{{ publishTime|isoDateTime }}</replace>
-  <replace sel="/MPD/PatchLocation[0]">
+  <replace sel="/MPD/PatchLocation[1]">
     <PatchLocation ttl="{{ patch.ttl }}">{{ patch.location }}</PatchLocation>
   </replace>
   {%- for period in periods %}
@@ -15,7 +15,7 @@
       {%- if adp.representations %}
         {%- with rep=adp.representations[0] %}
   <replace
-      sel="/MPD/Period[@id='{{ period.id }}']/AdaptationSet[@id='{{ adp.id }}']/SegmentTemplate/SegmentTimeline">
+      sel="/MPD/Period[@id='{{ period.id }}']/AdaptationSet[@id='{{ adp.id }}']/SegmentTemplate[1]/SegmentTimeline[1]">
     {% include "segment/timeline.xml" %}
   </replace>
         {% endwith -%}

--- a/templates/segment/timeline.xml
+++ b/templates/segment/timeline.xml
@@ -2,8 +2,8 @@
 <SegmentTimeline>
   {%- for seg in segTimeline %}
     <S d="{{seg.duration}}"
-      {%- if seg.repeat > 0 %} r="{{seg.repeat}}" {%- endif %}
-      {%- if seg.start != None %} t="{{seg.start}}" {%- endif %}
+      {%- if seg.repeat > 0 %} r="{{seg.repeat}}" {%- endif -%}
+      {%- if seg.start != None %} t="{{seg.start}}" {% endif -%}
     />
   {%- endfor %}
 </SegmentTimeline>  

--- a/tests/fixtures/hand_made_live.mpd
+++ b/tests/fixtures/hand_made_live.mpd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" publishTime="2022-09-06T15:10:02Z" type="dynamic" minimumUpdatePeriod="PT8S" suggestedPresentationDelay="PT30S" availabilityStartTime="2022-09-06T00:00:00Z" timeShiftBufferDepth="PT30M0S" profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:dvb:dash:profile:dvbdash:2014" minBufferTime="PT1.5S">
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" publishTime="2022-09-06T15:10:00Z" type="dynamic" minimumUpdatePeriod="PT8S" suggestedPresentationDelay="PT30S" availabilityStartTime="2022-09-06T00:00:00Z" timeShiftBufferDepth="PT30M0S" profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:dvb:dash:profile:dvbdash:2014" minBufferTime="PT1.5S">
   <ProgramInformation>
     <Title>Big Buck Bunny</Title>
   </ProgramInformation>

--- a/tests/fixtures/manifest_a_live.mpd
+++ b/tests/fixtures/manifest_a_live.mpd
@@ -9,7 +9,7 @@
   minimumUpdatePeriod="PT8S"
   timeShiftBufferDepth="PT30M0S"
     
-  publishTime="2023-10-25T07:56:58Z"
+  publishTime="2023-10-25T07:56:56Z"
   maxSegmentDuration="PT4S"
   minBufferTime="PT10S"
   profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:com:dashif:dash264,urn:hbbtv:dash:profile:isoff-live:2012">

--- a/tests/fixtures/manifest_e_live.mpd
+++ b/tests/fixtures/manifest_e_live.mpd
@@ -9,7 +9,7 @@ type="dynamic"
   timeShiftBufferDepth="PT30M0S"
   
   minBufferTime="PT5.000S" maxSegmentDuration="PT4S"
-  publishTime="2023-10-01T02:03:58Z"
+  publishTime="2023-10-01T02:03:52Z"
   profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:dvb:dash:profile:dvbdash:2014">
  <BaseURL>http://unit.test/dash/live/fixtures/</BaseURL>
  <Location>http://unit.test/dash/live/fixtures/manifest_e.mpd?start=2023-01-01T00:00:00Z</Location>

--- a/tests/fixtures/manifest_ef_live.mpd
+++ b/tests/fixtures/manifest_ef_live.mpd
@@ -4,7 +4,7 @@
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      minBufferTime="PT4.00S"
      profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014"
-     publishTime="2023-10-01T02:03:58Z"
+     publishTime="2023-10-01T02:03:52Z"
      
      type="dynamic"
      availabilityStartTime="2023-01-01T00:00:00Z"

--- a/tests/mixins/check_manifest.py
+++ b/tests/mixins/check_manifest.py
@@ -325,7 +325,8 @@ class DashManifestCheckMixin:
     def generate_manifest_context(self, mpd_filename: str, mode: str,
                                   stream: models.Stream, options: OptionsContainer) -> dict:
         mock = MockServeManifest(flask.request)
-        context = mock.calculate_manifest_params(mpd_url=mpd_filename, options=options)
+        context = mock.calculate_manifest_params(
+            mpd_name=mpd_filename, options=options)
         if options.encrypted:
             kids = set()
             for period in context['periods']:

--- a/tests/mixins/check_manifest.py
+++ b/tests/mixins/check_manifest.py
@@ -436,7 +436,7 @@ class DashManifestCheckMixin:
             act_value = actual.attrib[name]
             self.assertEqual(
                 exp_value, act_value,
-                msg='attribute {} should be "{}" but was "{}"'.format(
+                msg='attribute {} expected "{}" found "{}"'.format(
                     key_name, exp_value, act_value))
         counts = {}
         for exp, act in zip(expected, actual):

--- a/tests/mixins/mixin.py
+++ b/tests/mixins/mixin.py
@@ -21,18 +21,14 @@
 #############################################################################
 
 import binascii
-import datetime
 import logging
 import os
 import sys
 from typing import Any
-from unittest import mock
 
 from dashlive.utils.hexdump import hexdump_buffer
 
 class TestCaseMixin:
-    real_datetime_class = datetime.datetime
-
     @classmethod
     def classname(clz):
         if clz.__module__.startswith('__'):
@@ -311,42 +307,6 @@ class TestCaseMixin:
             print(item.keys())
             return f'{index}={item["atom_type"]}'
         return f'{index}'
-
-    @classmethod
-    def mock_datetime_now(cls, target):
-        """
-        Override ``datetime.datetime.now()`` with a custom target value.
-        This creates a new datetime.datetime class, and alters its now()/utcnow()
-        methods.
-        Returns:
-        A mock.patch context, can be used as a decorator or in a with.
-        """
-        # See http://bugs.python.org/msg68532
-        # And
-        # http://docs.python.org/reference/datamodel.html#customizing-instance-and-subclass-checks
-        class DatetimeSubclassMeta(type):
-            """
-            We need to customize the __instancecheck__ method for isinstance().
-            This must be performed at a metaclass level.
-            """
-            @classmethod
-            def __instancecheck__(mcs, obj):
-                return isinstance(obj, cls.real_datetime_class)
-
-        class BaseMockedDatetime(cls.real_datetime_class):
-            @classmethod
-            def now(cls, tz=None):
-                return target.replace(tzinfo=tz)
-
-            @classmethod
-            def utcnow(cls):
-                return target
-
-        # Python2 & Python3-compatible metaclass
-        MockedDatetime = DatetimeSubclassMeta(
-            'datetime', (BaseMockedDatetime,), {})
-        return mock.patch.object(datetime, 'datetime', MockedDatetime)
-
 
 class HideMixinsFilter(logging.Filter):
     """A logging.Filter that hides mixin.py in log messages.

--- a/tests/mixins/mock_time.py
+++ b/tests/mixins/mock_time.py
@@ -1,0 +1,108 @@
+import asyncio
+from contextlib import AsyncContextDecorator, ContextDecorator, asynccontextmanager
+import datetime
+import time
+from typing import Any, Callable, ClassVar, ContextManager
+from unittest import mock
+
+from dashlive.utils.date_time import from_isodatetime
+
+class MockTime(ContextDecorator, AsyncContextDecorator):
+    real_datetime_class = datetime.datetime
+    real_asyncio_sleep: ClassVar[Callable[[float], None]] = asyncio.sleep
+
+    now: datetime.datetime
+
+    def __init__(self, iso_now: str):
+        self.now = from_isodatetime(iso_now)
+
+        """
+        Override ``datetime.datetime.now()`` with a custom target value.
+        This creates a new datetime.datetime class, and alters its now()/utcnow()
+        methods.
+        Returns:
+        A mock.patch context, can be used as a decorator or in a with.
+        """
+        # See http://bugs.python.org/msg68532
+        # And
+        # http://docs.python.org/reference/datamodel.html#customizing-instance-and-subclass-checks
+        class DatetimeSubclassMeta(type):
+            """
+            We need to customize the __instancecheck__ method for isinstance().
+            This must be performed at a metaclass level.
+            """
+            @classmethod
+            def __instancecheck__(mcs, obj):
+                return isinstance(obj, MockTime.real_datetime_class)
+
+        class BaseMockedDatetime(MockTime.real_datetime_class):
+            @classmethod
+            def now(cls, tz=None) -> datetime.datetime:
+                return cls._get_now().replace(tzinfo=tz)
+
+            @classmethod
+            def utcnow(cls) -> datetime.datetime:
+                return cls._get_now()
+
+            @classmethod
+            def _get_now(cls) -> datetime.datetime:
+                raise RuntimeError('_get_now should have been replaced')
+
+        # Python2 & Python3-compatible metaclass
+        MockedDatetime = DatetimeSubclassMeta(
+            'datetime', (BaseMockedDatetime,), {})
+        MockedDatetime._get_now = self.get_now
+        self.datetime_patch = mock.patch.object(datetime, 'datetime', MockedDatetime)
+        self.asyncio_patch = mock.patch.object(
+            asyncio, 'sleep', self.mock_asyncio_sleep)
+        self.time_patch = mock.patch.multiple(
+            time,
+            localtime=self.mock_time_localtime, sleep=self.mock_time_sleep,
+            time=self.mock_time_time)
+
+    def __enter__(self) -> ContextManager["MockTime"]:
+        return self.__do_enter()
+
+    async def __aenter__(self) -> ContextManager["MockTime"]:
+        return self.__do_enter()
+
+    def __do_enter(self) -> ContextManager["MockTime"]:
+        self.asyncio_patch.start()
+        self.datetime_patch.start()
+        self.time_patch.start()
+        return self
+
+    def __exit__(self, *args) -> bool:
+        self.__do_exit()
+        return False
+
+    async def __aexit__(self, *args) -> bool:
+        self.__do_exit()
+        return False
+
+    def __do_exit(self) -> None:
+        self.time_patch.stop()
+        self.datetime_patch.stop()
+        self.asyncio_patch.stop()
+
+    def get_now(self) -> datetime.datetime:
+        return self.now
+
+    def mock_time_sleep(self, duration: float) -> None:
+        self.now += datetime.timedelta(seconds=duration)
+
+    async def mock_asyncio_sleep(self, duration: float, result: Any = None) -> None:
+        self.now += datetime.timedelta(seconds=duration)
+        return await MockTime.real_asyncio_sleep(0, result=result)
+
+    def mock_time_time(self) -> float:
+        return self.now.timestamp()
+
+    def mock_time_localtime(self) -> time.struct_time:
+        return self.now.timetuple()
+
+
+@asynccontextmanager
+async def async_mock_time(now: str) -> ContextManager[MockTime]:
+    with MockTime(now) as mt:
+        yield mt

--- a/tests/mixins/view_validator.py
+++ b/tests/mixins/view_validator.py
@@ -21,6 +21,9 @@
 #############################################################################
 
 import logging
+from typing import Optional
+
+from lxml import etree as ET
 
 from dashlive.server import models
 from dashlive.mpeg.dash.validator import (
@@ -52,8 +55,10 @@ class ViewsTestDashValidator(DashValidator):
             mode=mode,
             options=opts)
 
-    async def load(self, xml=None) -> bool:
-        rv = await super().load(xml)
+    async def load(self,
+                   xml: Optional[ET.ElementBase] = None,
+                   data: Optional[bytes] = None) -> bool:
+        rv = await super().load(xml=xml, data=data)
         for mf in models.MediaFile.all():
             self.set_representation_info(mf.representation)
         return rv

--- a/tests/test_cgi_options.py
+++ b/tests/test_cgi_options.py
@@ -1,4 +1,3 @@
-import datetime
 import unittest
 
 from dashlive.server.options.drm_options import DrmSelection
@@ -7,6 +6,7 @@ from dashlive.server.options.repository import OptionsRepository
 from dashlive.server.options.types import OptionUsage
 from dashlive.server.requesthandler.base import RequestHandlerBase
 
+from .mixins.mock_time import MockTime
 from .mixins.mixin import TestCaseMixin
 
 class TestServerOptions(TestCaseMixin, unittest.TestCase):
@@ -70,7 +70,7 @@ class TestServerOptions(TestCaseMixin, unittest.TestCase):
             self.assertNotIn(opt.name, names)
             names.add(opt.name)
 
-    @TestCaseMixin.mock_datetime_now(datetime.datetime(2023, 4, 5, 6, 30))
+    @MockTime("2023-04-05T06:30:00Z")
     def test_convert_cgi_options(self) -> None:
         params = {
             'abr': '1',
@@ -207,7 +207,7 @@ class TestServerOptions(TestCaseMixin, unittest.TestCase):
                 ('playready', {'cenc', 'moov'})
             ])
 
-    @TestCaseMixin.mock_datetime_now(datetime.datetime(2023, 4, 5, 6, 30))
+    @MockTime("2023-04-05T06:30:00Z")
     def test_default_values(self) -> None:
         expected = {
             '_type': 'dashlive.server.options.container.OptionsContainer',

--- a/tests/test_cgi_options.py
+++ b/tests/test_cgi_options.py
@@ -237,6 +237,7 @@ class TestServerOptions(TestCaseMixin, unittest.TestCase):
             },
             'minimumUpdatePeriod': None,
             'numPeriods': None,
+            'patch': False,
             'ping': {
                 '_type': 'dashlive.server.options.container.OptionsContainer',
                 'count': 0,
@@ -403,6 +404,7 @@ class TestServerOptions(TestCaseMixin, unittest.TestCase):
             "minimumUpdatePeriod": None,
             "mode": "vod",
             "numPeriods": None,
+            "patch": False,
             "ping": {
                 "_type": "dashlive.server.options.container.OptionsContainer",
                 "count": 5,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -54,8 +54,9 @@ class TestDashEventGeneration(DashManifestCheckMixin, FlaskTestBase):
             stream=self.FIXTURES_PATH.name,
             **params)
         dv = await self.check_manifest_url(
-            url, 'vod', encrypted=False, check_media=False, check_head=False, debug=False,
-            duration=self.SEGMENT_DURATION)
+            url, mode='vod', encrypted=False, check_media=False, check_head=False,
+            debug=False, duration=self.SEGMENT_DURATION,
+            now='2024-09-03T10:07:00Z')
         for period in dv.manifest.periods:
             self.assertEqual(len(period.event_streams), 1)
             event_stream = period.event_streams[0]
@@ -89,7 +90,8 @@ class TestDashEventGeneration(DashManifestCheckMixin, FlaskTestBase):
             stream=self.FIXTURES_PATH.name,
             **params)
         dv = await self.check_manifest_url(
-            url, 'vod', encrypted=False, check_media=True, check_head=False, debug=False,
+            url, 'vod', encrypted=False, check_media=True, check_head=False,
+            debug=False, now='2024-09-03T10:07:00Z',
             duration=int(self.MEDIA_DURATION // 2))
         for period in dv.manifest.periods:
             for adp in period.adaptation_sets:
@@ -167,7 +169,8 @@ class TestDashEventGeneration(DashManifestCheckMixin, FlaskTestBase):
             stream=self.FIXTURES_PATH.name,
             **params)
         dv = await self.check_manifest_url(
-            url, 'vod', encrypted=False, check_media=False, check_head=False, debug=False,
+            url, 'vod', encrypted=False, check_media=False, check_head=False,
+            debug=False, now='2024-09-03T10:07:00Z',
             duration=self.SEGMENT_DURATION)
         for period in dv.manifest.periods:
             self.assertEqual(len(period.event_streams), 1)

--- a/tests/test_hand_made_manifest.py
+++ b/tests/test_hand_made_manifest.py
@@ -163,6 +163,12 @@ class HandMadeManifestTests(FlaskTestBase, DashManifestCheckMixin):
             'hand_made.mpd', mode='live', drm='all', encrypted=True,
             acodec='mp4a', time='xsd', start='today')
 
+    @FlaskTestBase.mock_datetime_now(from_isodatetime("2023-09-06T09:59:02Z"))
+    async def test_manifest_patch_live_aac(self):
+        await self.check_a_manifest_using_all_options(
+            'hand_made.mpd', 'live', simplified=True, audioCodec='mp4a',
+            segmentTimeline=True, patch=True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_hand_made_manifest.py
+++ b/tests/test_hand_made_manifest.py
@@ -25,8 +25,9 @@ import flask
 
 from dashlive.utils.date_time import from_isodatetime
 
-from .mixins.flask_base import FlaskTestBase
 from .mixins.check_manifest import DashManifestCheckMixin
+from .mixins.flask_base import FlaskTestBase
+from .mixins.mock_time import MockTime
 
 class HandMadeManifestTests(FlaskTestBase, DashManifestCheckMixin):
     async def test_hand_made_manifest_aac_vod(self):
@@ -59,50 +60,44 @@ class HandMadeManifestTests(FlaskTestBase, DashManifestCheckMixin):
             'hand_made.mpd', 'vod', with_subs=True, audioCodec='any',
             segmentTimeline=True)
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2023-09-06T09:59:02Z"))
     async def test_hand_made_manifest_live_aac(self):
         await self.check_a_manifest_using_all_options(
             'hand_made.mpd', 'live', with_subs=True, audioCodec='mp4a',
-            segmentTimeline=False)
+            segmentTimeline=False, now="2023-09-06T09:59:02Z")
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2021-09-06T09:59:02Z"))
     async def test_hand_made_manifest_live_ec3(self):
         await self.check_a_manifest_using_all_options(
             'hand_made.mpd', 'live', with_subs=True, audioCodec='ec-3',
-            segmentTimeline=False)
+            segmentTimeline=False, now="2021-09-06T09:59:02Z")
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2020-09-06T09:59:02Z"))
     async def test_hand_made_manifest_live_all_audio(self):
         await self.check_a_manifest_using_all_options(
             'hand_made.mpd', 'live', with_subs=True, audioCodec='any',
-            segmentTimeline=False)
+            segmentTimeline=False, now="2020-09-06T09:59:02Z")
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2023-09-06T09:59:02Z"))
     async def test_hand_made_manifest_live_aac_timeline(self):
         await self.check_a_manifest_using_all_options(
             'hand_made.mpd', 'live', with_subs=True, audioCodec='mp4a',
-            segmentTimeline=True)
+            segmentTimeline=True, now="2023-09-06T09:59:02Z")
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2021-09-06T09:59:02Z"))
     async def test_hand_made_manifest_live_ec3_timeline(self):
         await self.check_a_manifest_using_all_options(
             'hand_made.mpd', 'live', with_subs=True, audioCodec='ec-3',
-            segmentTimeline=True)
+            segmentTimeline=True, now="2021-09-06T09:59:02Z")
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2020-09-06T09:59:02Z"))
     async def test_hand_made_manifest_live_all_audio_timeline(self):
         await self.check_a_manifest_using_all_options(
             'hand_made.mpd', 'live', with_subs=True, audioCodec='any',
-            segmentTimeline=True)
+            now="2020-09-06T09:59:02Z", segmentTimeline=True)
 
     async def test_hand_made_manifest_vod_abr(self):
         await self.check_a_manifest_using_all_options(
             'hand_made.mpd', 'vod', only={'abr', 'audioCodec'})
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2020-10-07T09:59:02Z"))
     async def test_hand_made_manifest_live_abr(self):
         await self.check_a_manifest_using_all_options(
-            'hand_made.mpd', 'live', abr=True, only={'audioCodec', 'minimumupdateperiod'})
+            'hand_made.mpd', 'live', abr=True, now="2020-10-07T09:59:02Z",
+            only={'audioCodec', 'minimumupdateperiod'})
 
     async def test_hand_made_manifest_odvod_aac(self):
         await self.check_a_manifest_using_all_options(
@@ -121,53 +116,53 @@ class HandMadeManifestTests(FlaskTestBase, DashManifestCheckMixin):
         url = flask.url_for('dash-mpd-v1', manifest='manifest_vod.mpd')
         await self.check_manifest_url(
             url, mode="vod", encrypted=False, check_head=True, debug=False,
-            check_media=False, duration=(2 * self.SEGMENT_DURATION))
+            check_media=False, duration=(2 * self.SEGMENT_DURATION),
+            now='2024-09-03T10:07:00Z')
 
     async def test_legacy_encrypted_manifest_name_vod(self):
         self.setup_media()
         url = flask.url_for('dash-mpd-v1', manifest='enc.mpd')
         await self.check_manifest_url(
             url, mode="vod", encrypted=True, check_head=True, check_media=False,
-            debug=False, duration=(2 * self.SEGMENT_DURATION))
+            debug=False, duration=(2 * self.SEGMENT_DURATION),
+            now='2024-09-03T10:07:00Z')
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2020-10-07T09:59:02Z"))
     async def test_legacy_encrypted_manifest_name_live(self):
         self.setup_media()
         url = flask.url_for('dash-mpd-v1', manifest='enc.mpd')
         url += '?mode=live'
-        await self.check_manifest_url(
-            url, mode="live", encrypted=True, check_head=True, check_media=False,
-            debug=False, duration=(2 * self.SEGMENT_DURATION))
+        with MockTime("2020-10-07T09:59:02Z"):
+            await self.check_manifest_url(
+                url, mode="live", encrypted=True, check_head=True,
+                check_media=False, debug=False,
+                duration=(2 * self.SEGMENT_DURATION),
+                now='2024-09-03T10:07:00Z')
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2022-09-06T15:10:02Z"))
     def test_generated_vod_manifest_against_fixture(self):
         self.check_generated_manifest_against_fixture(
             'hand_made.mpd', mode='vod', acodec='mp4a', start='today', drm='none',
-            encrypted=False)
+            encrypted=False, now="2022-09-06T15:10:02Z")
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2022-09-06T15:10:00Z"))
     def test_generated_vod_drm_manifest_against_fixture(self):
         self.check_generated_manifest_against_fixture(
             'hand_made.mpd', mode='vod', drm='all', encrypted=True,
-            acodec='mp4a', start='today')
+            acodec='mp4a', start='today', now="2022-09-06T15:10:00Z")
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2022-09-06T15:10:02Z"))
     def test_generated_live_manifest_against_fixture(self):
         self.check_generated_manifest_against_fixture(
             'hand_made.mpd', mode='live', acodec='mp4a', time='xsd', start='today',
-            drm='none', encrypted=False)
+            now="2022-09-06T15:10:02Z", drm='none', encrypted=False)
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2022-09-06T15:10:00Z"))
     def test_generated_live_drm_manifest_against_fixture(self):
         self.check_generated_manifest_against_fixture(
             'hand_made.mpd', mode='live', drm='all', encrypted=True,
+            now="2022-09-06T15:10:00Z",
             acodec='mp4a', time='xsd', start='today')
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2023-09-06T09:59:02Z"))
     async def test_manifest_patch_live_aac(self):
         await self.check_a_manifest_using_all_options(
             'hand_made.mpd', 'live', simplified=True, audioCodec='mp4a',
-            segmentTimeline=True, patch=True)
+            segmentTimeline=True, patch=True, now="2023-09-06T09:59:02Z")
 
 
 if __name__ == '__main__':

--- a/tests/test_manifest_a.py
+++ b/tests/test_manifest_a.py
@@ -19,7 +19,6 @@
 #  Author              :    Alex Ashley
 #
 #############################################################################
-import datetime
 import unittest
 
 from .mixins.check_manifest import DashManifestCheckMixin
@@ -29,19 +28,19 @@ class ManifestATest(FlaskTestBase, DashManifestCheckMixin):
     async def test_manifest_a_vod(self):
         await self.check_a_manifest_using_major_options('manifest_a.mpd', 'vod')
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-10-25T07:56:58Z"))
     async def test_manifest_a_live(self):
-        await self.check_a_manifest_using_major_options('manifest_a.mpd', 'live', debug=False)
+        await self.check_a_manifest_using_major_options(
+            'manifest_a.mpd', 'live', debug=False, now="2023-10-25T07:56:58Z")
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-10-25T07:56:58Z"))
     def test_generated_manifest_against_fixture_vod(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_a.mpd', mode='vod', acodec='mp4a', encrypted=False)
+            'manifest_a.mpd', mode='vod', acodec='mp4a', encrypted=False,
+            now="2023-10-25T07:56:58Z")
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-10-25T07:56:58Z"))
     def test_generated_manifest_against_fixture_live(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_a.mpd', mode='live', acodec='mp4a', encrypted=False)
+            'manifest_a.mpd', mode='live', acodec='mp4a', encrypted=False,
+            now="2023-10-25T07:56:58Z")
 
 
 if __name__ == '__main__':

--- a/tests/test_manifest_aiv.py
+++ b/tests/test_manifest_aiv.py
@@ -19,7 +19,6 @@
 #  Author              :    Alex Ashley
 #
 #############################################################################
-import datetime
 import unittest
 
 import flask
@@ -37,10 +36,10 @@ class ManifestAIVTest(FlaskTestBase, DashManifestCheckMixin):
             stream=self.FIXTURES_PATH.name, mode='live')
         self.app.get(baseurl, status=404)
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-10-05T20:19:58Z"))
     def test_generated_manifest_against_fixture(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_vod_aiv.mpd', mode='vod', acodec='mp4a', encrypted=False)
+            'manifest_vod_aiv.mpd', mode='vod', acodec='mp4a', encrypted=False,
+            now="2023-10-05T20:19:58Z")
 
 
 if __name__ == '__main__':

--- a/tests/test_manifest_b.py
+++ b/tests/test_manifest_b.py
@@ -19,7 +19,6 @@
 #  Author              :    Alex Ashley
 #
 #############################################################################
-import datetime
 import unittest
 
 from .mixins.check_manifest import DashManifestCheckMixin
@@ -29,10 +28,10 @@ class ManifestBTest(FlaskTestBase, DashManifestCheckMixin):
     async def test_manifest_b(self):
         await self.check_a_manifest_using_major_options('manifest_b.mpd', 'vod')
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-10-25T08:56:58Z"))
     def test_generated_manifest_against_fixture_vod(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_b.mpd', mode='vod', acodec='mp4a', encrypted=False)
+            'manifest_b.mpd', mode='vod', acodec='mp4a', encrypted=False,
+            now="2023-10-25T08:56:58Z")
 
 
 if __name__ == '__main__':

--- a/tests/test_manifest_e.py
+++ b/tests/test_manifest_e.py
@@ -19,7 +19,6 @@
 #  Author              :    Alex Ashley
 #
 #############################################################################
-import datetime
 import unittest
 
 from .mixins.check_manifest import DashManifestCheckMixin
@@ -29,19 +28,19 @@ class ManifestETest(FlaskTestBase, DashManifestCheckMixin):
     async def test_manifest_e_vod(self):
         await self.check_a_manifest_using_major_options('manifest_e.mpd', 'vod')
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-10-01T02:03:58Z"))
     async def test_manifest_e_live(self):
-        await self.check_a_manifest_using_major_options('manifest_e.mpd', 'live')
+        await self.check_a_manifest_using_major_options(
+            'manifest_e.mpd', 'live', now="2023-10-01T02:03:58Z")
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-10-01T02:03:58Z"))
     def test_generated_manifest_against_fixture_vod(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_e.mpd', mode='vod', acodec='mp4a', encrypted=False)
+            'manifest_e.mpd', mode='vod', acodec='mp4a', encrypted=False,
+            now="2023-10-01T02:03:58Z")
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-10-01T02:03:58Z"))
     def test_generated_manifest_against_fixture_live(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_e.mpd', mode='live', acodec='mp4a', encrypted=False)
+            'manifest_e.mpd', mode='live', acodec='mp4a', encrypted=False,
+            now="2023-10-01T02:03:58Z")
 
 
 if __name__ == '__main__':

--- a/tests/test_manifest_ef.py
+++ b/tests/test_manifest_ef.py
@@ -19,7 +19,6 @@
 #  Author              :    Alex Ashley
 #
 #############################################################################
-import datetime
 import unittest
 
 from .mixins.check_manifest import DashManifestCheckMixin
@@ -29,19 +28,19 @@ class ManifestEFTest(FlaskTestBase, DashManifestCheckMixin):
     async def test_manifest_ef_vod(self):
         await self.check_a_manifest_using_major_options('manifest_ef.mpd', 'vod')
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-10-07T01:06:00Z"))
     async def test_manifest_ef_live(self):
-        await self.check_a_manifest_using_major_options('manifest_ef.mpd', 'live')
+        await self.check_a_manifest_using_major_options(
+            'manifest_ef.mpd', 'live', now="2023-10-07T01:06:00Z")
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-10-01T02:03:58Z"))
     def test_generated_manifest_against_fixture_vod(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_ef.mpd', mode='vod', acodec='mp4a', encrypted=False)
+            'manifest_ef.mpd', mode='vod', acodec='mp4a', encrypted=False,
+            now="2023-10-01T02:03:58Z")
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-10-01T02:03:58Z"))
     def test_generated_manifest_against_fixture_live(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_ef.mpd', mode='live', acodec='mp4a', encrypted=False)
+            'manifest_ef.mpd', mode='live', acodec='mp4a', encrypted=False,
+            now="2023-10-01T02:03:58Z")
 
 
 if __name__ == '__main__':

--- a/tests/test_manifest_h.py
+++ b/tests/test_manifest_h.py
@@ -19,7 +19,6 @@
 #  Author              :    Alex Ashley
 #
 #############################################################################
-import datetime
 import unittest
 
 from .mixins.check_manifest import DashManifestCheckMixin
@@ -29,19 +28,19 @@ class ManifestHTest(FlaskTestBase, DashManifestCheckMixin):
     async def test_manifest_h_vod(self):
         await self.check_a_manifest_using_major_options('manifest_h.mpd', 'vod')
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-09-10T17:56:43Z"))
     async def test_manifest_h_live(self):
-        await self.check_a_manifest_using_major_options('manifest_h.mpd', 'live')
+        await self.check_a_manifest_using_major_options(
+            'manifest_h.mpd', 'live', now="2023-09-10T17:56:43Z")
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-09-10T17:56:43Z"))
     def test_generated_manifest_against_fixture_vod(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_h.mpd', mode='vod', acodec='mp4a', encrypted=False)
+            'manifest_h.mpd', mode='vod', acodec='mp4a', encrypted=False,
+            now="2023-09-10T17:56:43Z")
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-09-10T17:56:43Z"))
     def test_generated_manifest_against_fixture_live(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_h.mpd', mode='live', acodec='mp4a', encrypted=False)
+            'manifest_h.mpd', mode='live', acodec='mp4a', encrypted=False,
+            now="2023-09-10T17:56:43Z")
 
 
 if __name__ == '__main__':

--- a/tests/test_manifest_i.py
+++ b/tests/test_manifest_i.py
@@ -19,7 +19,6 @@
 #  Author              :    Alex Ashley
 #
 #############################################################################
-import datetime
 import unittest
 
 from .mixins.check_manifest import DashManifestCheckMixin
@@ -29,19 +28,19 @@ class ManifestITest(FlaskTestBase, DashManifestCheckMixin):
     async def test_manifest_i_vod(self):
         await self.check_a_manifest_using_major_options('manifest_i.mpd', 'vod')
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-08-07T17:56:43Z"))
     async def test_manifest_i_live(self):
-        await self.check_a_manifest_using_major_options('manifest_i.mpd', 'live')
+        await self.check_a_manifest_using_major_options(
+            'manifest_i.mpd', 'live', now="2023-08-07T17:56:43Z")
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-08-07T17:56:43Z"))
     def test_generated_manifest_against_fixture_vod(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_i.mpd', mode='vod', acodec='mp4a', encrypted=False)
+            'manifest_i.mpd', mode='vod', acodec='mp4a', encrypted=False,
+            now="2023-08-07T17:56:43Z")
 
-    @FlaskTestBase.mock_datetime_now(datetime.datetime.fromisoformat("2023-08-07T17:56:43Z"))
     def test_generated_manifest_against_fixture_live(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_i.mpd', mode='live', acodec='mp4a', encrypted=False)
+            'manifest_i.mpd', mode='live', acodec='mp4a', encrypted=False,
+            now="2023-08-07T17:56:43Z")
 
 
 if __name__ == '__main__':

--- a/tests/test_manifest_n.py
+++ b/tests/test_manifest_n.py
@@ -21,8 +21,6 @@
 #############################################################################
 import unittest
 
-from dashlive.utils.date_time import from_isodatetime
-
 from .mixins.check_manifest import DashManifestCheckMixin
 from .mixins.flask_base import FlaskTestBase
 
@@ -30,20 +28,19 @@ class ManifestNTests(FlaskTestBase, DashManifestCheckMixin):
     async def test_manifest_n_vod(self):
         await self.check_a_manifest_using_all_options('manifest_n.mpd', 'vod')
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2022-09-06T09:59:02Z"))
     async def test_manifest_n_live(self):
-        await self.check_a_manifest_using_all_options('manifest_n.mpd', 'live')
+        await self.check_a_manifest_using_all_options(
+            'manifest_n.mpd', 'live', now="2022-09-06T09:59:02Z")
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2022-09-06T09:59:02Z"))
     def test_generated_manifest_against_fixture(self):
         self.check_generated_manifest_against_fixture(
-            'manifest_n.mpd', mode='vod', acodec='mp4a', encrypted=False)
+            'manifest_n.mpd', mode='vod', acodec='mp4a', encrypted=False,
+            now="2022-09-06T09:59:02Z")
 
-    @FlaskTestBase.mock_datetime_now(from_isodatetime("2022-09-06T11:57:00Z"))
     def test_generated_drm_manifest_against_fixture(self):
         self.check_generated_manifest_against_fixture(
             'manifest_n.mpd', mode='vod', drm='all',
-            acodec='mp4a', encrypted=True)
+            acodec='mp4a', encrypted=True, now="2022-09-06T11:57:00Z")
 
 
 if __name__ == '__main__':

--- a/tests/test_mock_time.py
+++ b/tests/test_mock_time.py
@@ -1,0 +1,59 @@
+import asyncio
+import datetime
+import logging
+import time
+import unittest
+
+from dashlive.utils.date_time import to_iso_datetime
+
+# from .mixins.mixin import TestCaseMixin
+from .mixins.mock_time import MockTime, async_mock_time
+
+class TestMockTime(unittest.IsolatedAsyncioTestCase):
+    def test_unix_epoch(self) -> None:
+        epoch = '1970-01-01T00:00:00Z'
+        with MockTime(epoch):
+            self.assertEqual(to_iso_datetime(datetime.datetime.now()), epoch)
+            self.assertEqual(to_iso_datetime(datetime.datetime.utcnow()), epoch)
+            self.assertAlmostEqual(time.time(), 0)
+            expected: time.struct_time = (1970, 1, 1, 0, 0, 0, 3, 1, 0)
+            self.assertEqual(time.localtime(), expected)
+
+    def test_time_sleep(self) -> None:
+        now = '2024-02-09T10:52:00Z'
+        with MockTime(now):
+            before = datetime.datetime.now()
+            time.sleep(30)
+            after = datetime.datetime.now()
+            self.assertEqual(after - before, datetime.timedelta(seconds=30))
+            self.assertEqual(
+                to_iso_datetime(datetime.datetime.now()),
+                '2024-02-09T10:52:30Z')
+
+    async def test_asyncio_sleep(self) -> None:
+        now = '2024-02-09T10:52:00Z'
+        async with MockTime(now):
+            before = datetime.datetime.now()
+            await asyncio.sleep(25)
+            after = datetime.datetime.now()
+            self.assertEqual(after - before, datetime.timedelta(seconds=25))
+            self.assertEqual(
+                to_iso_datetime(datetime.datetime.now()),
+                '2024-02-09T10:52:25Z')
+
+    @async_mock_time('2024-02-09T10:52:00Z')
+    async def test_async_mock_time_decorator(self) -> None:
+        before = datetime.datetime.now()
+        self.assertEqual(to_iso_datetime(before), '2024-02-09T10:52:00Z')
+        await asyncio.sleep(25)
+        after = datetime.datetime.now()
+        self.assertEqual(after - before, datetime.timedelta(seconds=25))
+        self.assertEqual(
+            to_iso_datetime(datetime.datetime.now()),
+            '2024-02-09T10:52:25Z')
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    logging.getLogger().setLevel(logging.INFO)
+    unittest.main()

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -27,13 +27,12 @@ from bs4 import BeautifulSoup
 import flask
 from werkzeug.test import TestResponse
 
-from dashlive.utils.date_time import from_isodatetime
 from dashlive.server.models import Group, User, db
 
 from .mixins.flask_base import FlaskTestBase
+from .mixins.mock_time import MockTime
 
 class TestUserManagementHandlers(FlaskTestBase):
-    NOW = from_isodatetime("2023-07-18T20:10:02Z")
 
     def test_html_login_page(self):
         url = flask.url_for('login')
@@ -93,7 +92,7 @@ class TestUserManagementHandlers(FlaskTestBase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Wrong username or password", response.text)
 
-    @FlaskTestBase.mock_datetime_now(NOW)
+    @MockTime("2023-07-18T20:10:02Z")
     def test_ajax_login_page(self):
         url = flask.url_for('login', ajax=1)
         response = self.client.get(url)

--- a/tests/test_utctime.py
+++ b/tests/test_utctime.py
@@ -21,22 +21,21 @@
 #############################################################################
 
 import datetime
-import logging
-import os
 import struct
 import unittest
 
 import flask
 
-from dashlive.utils.date_time import to_iso_datetime, from_isodatetime
+from dashlive.utils.date_time import from_isodatetime
 from dashlive.utils.timezone import UTC
 
 from .mixins.flask_base import FlaskTestBase
+from .mixins.mock_time import MockTime
 
 class TestUtcTime(FlaskTestBase):
-    NOW = from_isodatetime("2023-07-18T20:10:02Z")
+    NOW = "2023-07-18T20:10:02Z"
 
-    @FlaskTestBase.mock_datetime_now(NOW)
+    @MockTime(NOW)
     def test_head_request(self):
         url = flask.url_for('time', format='head')
         response = self.client.head(url)
@@ -44,16 +43,16 @@ class TestUtcTime(FlaskTestBase):
         self.assertEqual(response.headers['Date'], 'Tue, 18 Jul 2023 20:10:02 UTC')
         self.assertEqual(response.headers['Content-Type'], 'text/plain')
 
-    @FlaskTestBase.mock_datetime_now(NOW)
+    @MockTime(NOW)
     def test_xsd_request(self):
         url = flask.url_for('time', format='xsd')
         response = self.client.get(url)
         self.assert200(response)
         self.assertEqual(response.headers['Date'], 'Tue, 18 Jul 2023 20:10:02 UTC')
         self.assertEqual(response.headers['Content-Type'], 'text/plain')
-        self.assertEqual(response.text, to_iso_datetime(self.NOW))
+        self.assertEqual(response.text, self.NOW)
 
-    @FlaskTestBase.mock_datetime_now(NOW)
+    @MockTime(NOW)
     def test_iso_request(self):
         url = flask.url_for('time', format='iso')
         response = self.client.get(url)
@@ -62,7 +61,7 @@ class TestUtcTime(FlaskTestBase):
         self.assertEqual(response.headers['Content-Type'], 'text/plain')
         self.assertEqual(response.text, '2023-W29-2T20:10:02Z')
 
-    @FlaskTestBase.mock_datetime_now(NOW)
+    @MockTime(NOW)
     def test_ntp_request(self):
         url = flask.url_for('time', format='http-ntp')
         response = self.client.get(url)
@@ -72,17 +71,10 @@ class TestUtcTime(FlaskTestBase):
         data = response.get_data(as_text=False)
         parts = struct.unpack('>II', data)
         ntp_epoch = datetime.datetime(year=1900, month=1, day=1, tzinfo=UTC())
-        seconds = (self.NOW - ntp_epoch).total_seconds()
+        seconds = (from_isodatetime(self.NOW) - ntp_epoch).total_seconds()
         self.assertEqual(parts[0], seconds)
         self.assertEqual(parts[1], 0)
 
-
-if os.environ.get("TESTS"):
-    def load_tests(loader, tests, pattern):
-        logging.basicConfig()
-        return unittest.loader.TestLoader().loadTestsFromNames(
-            os.environ["TESTS"].split(','),
-            TestUtcTime)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -108,8 +108,12 @@ class TestHandlers(DashManifestCheckMixin, FlaskTestBase):
                 self.assertEqual(option, '2019-09-invalid-iso-datetime')
 
             def mocked_info(*args):
-                self.assertIn('moving availabilityStartTime back one day', args[0])
-                self.assertEqual(now, ref_today)
+                if 'Invalid CGI parameters' in args[0]:
+                    self.assertIn('invalid-iso', option)
+                    self.assertIn(option, ' '.join([str(a) for a in args]))
+                elif 'availabilityStartTime' in args[0]:
+                    self.assertIn('moving availabilityStartTime back one day', args[0])
+                    self.assertEqual(now, ref_today)
 
             with MockTime(now):
                 baseurl = flask.url_for(


### PR DESCRIPTION
The 2022 version of the DASH specification added support for MPD patches. These are XML documents that can be applied to an in-memory version of a complete MPD to modify the manifest. Its primary use is to avoid having to keep fetching the whole manifest for live streams that use `SegmentTimeline`.

This initial implementation just replaces the `SegmentTimeline` elements in each `AdaptationSet`. Ideally this will be extended to use the "add" patch command to just add the new `<S>` nodes to the existing in-memory `SegmentTimeline`.
