### PR TITLE
  Use type hinting for template contexts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ WORKDIR /home/dash/dash-live
 RUN python ./gen-settings.py --password=${DEFAULT_PASSWORD} --proxy-depth=${PROXY_DEPTH}
 RUN echo "#!/bin/bash" > $HOME/dash-live/lesscpy.sh
 RUN echo "source $HOME/.venv/bin/activate && python -m lesscpy static/css -o static/css/" >> $HOME/dash-live/lesscpy.sh
-RUN chmod +x $HOME/dash-live/lesscpy.sh
+COPY deploy/runtests.sh $HOME/dash-live/
+RUN chmod +x $HOME/dash-live/*.sh
 RUN $HOME/dash-live/lesscpy.sh
 ENTRYPOINT ["/home/dash/dash-live/runserver.sh"]
 
@@ -74,7 +75,6 @@ RUN apt-get -y -q --force-yes install nginx
 RUN rm /etc/nginx/sites-enabled/default
 COPY deploy/application.py $HOME/dash-live/
 COPY deploy/start-server.sh $HOME/dash-live/
-COPY deploy/runtests.sh $HOME/dash-live/
 COPY deploy/dashlive.conf /etc/nginx/sites-available/
 COPY deploy/x_forwarded_proto.conf /etc/nginx/conf.d/
 COPY deploy/proxy_params /etc/nginx/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,13 @@ COPY static/js/*.js $HOME/dash-live/static/js/
 COPY static/js/dev/* $HOME/dash-live/static/js/dev/
 COPY static/js/legacy/* $HOME/dash-live/static/js/legacy/
 COPY static/js/prod/* $HOME/dash-live/static/js/prod/
-COPY templates/esm/*.js $HOME/dash-live/templates/esm/
-COPY templates/manifests/*.mpd $HOME/dash-live/templates/manifests/
 COPY templates/*.html $HOME/dash-live/templates/
 COPY templates/drm/*.xml $HOME/dash-live/templates/drm/
+COPY templates/esm/*.js $HOME/dash-live/templates/esm/
 COPY templates/events/*.xml $HOME/dash-live/templates/events/
+COPY templates/manifests/*.mpd $HOME/dash-live/templates/manifests/
 COPY templates/media/*.html $HOME/dash-live/templates/media/
+COPY templates/patches/*.xml $HOME/dash-live/templates/patches/
 COPY templates/segment/*.xml $HOME/dash-live/templates/segment/
 COPY templates/users/*.html $HOME/dash-live/templates/users/
 COPY static/css/* $HOME/dash-live/static/css/

--- a/dashlive/drm/base.py
+++ b/dashlive/drm/base.py
@@ -28,6 +28,7 @@ from dashlive.server.models import Stream
 from dashlive.server.options.container import OptionsContainer
 
 from .key_tuple import KeyTuple
+from .location import DrmLocation
 from .system import DrmSystem
 
 class CustomAttribute(NamedTuple):
@@ -77,7 +78,7 @@ class DrmBase(ABC):
                                   options: OptionsContainer,
                                   la_url: str | None = None,
                                   https_request: bool = False,
-                                  locations: AbstractSet[str] | None = None) -> DrmManifestContext:
+                                  locations: AbstractSet[DrmLocation] | None = None) -> DrmManifestContext:
         raise RuntimeError('generate_manifest_context has not been implemented')
 
     def update_traf_if_required(self, options: OptionsContainer,

--- a/dashlive/drm/base.py
+++ b/dashlive/drm/base.py
@@ -28,6 +28,7 @@ from dashlive.server.models import Stream
 from dashlive.server.options.container import OptionsContainer
 
 from .key_tuple import KeyTuple
+from .system import DrmSystem
 
 class CustomAttribute(NamedTuple):
     tag: str
@@ -51,9 +52,10 @@ class CreatePsshBox(Protocol):
         ...
 
 
-class ManifestContext(NamedTuple):
+class DrmManifestContext(NamedTuple):
     laurl: str
     scheme_id: str
+    system: DrmSystem
     version: float
     cenc: CreatePsshBox | None
     moov: CreatePsshBox | None
@@ -75,7 +77,7 @@ class DrmBase(ABC):
                                   options: OptionsContainer,
                                   la_url: str | None = None,
                                   https_request: bool = False,
-                                  locations: AbstractSet[str] | None = None) -> ManifestContext:
+                                  locations: AbstractSet[str] | None = None) -> DrmManifestContext:
         raise RuntimeError('generate_manifest_context has not been implemented')
 
     def update_traf_if_required(self, options: OptionsContainer,

--- a/dashlive/drm/clearkey.py
+++ b/dashlive/drm/clearkey.py
@@ -33,6 +33,7 @@ from dashlive.server.models import Stream
 from .base import CreateDrmData, DrmBase, DrmManifestContext
 from .keymaterial import KeyMaterial
 from .key_tuple import KeyTuple
+from .location import DrmLocation
 from .system import DrmSystem
 
 class ClearKey(DrmBase):
@@ -49,9 +50,9 @@ class ClearKey(DrmBase):
             options: OptionsContainer,
             la_url: str | None = None,
             https_request: bool = False,
-            locations: AbstractSet[str] | None = None) -> DrmManifestContext:
+            locations: AbstractSet[DrmLocation] | None = None) -> DrmManifestContext:
         if locations is None:
-            locations = {'cenc', 'moov'}
+            locations = {DrmLocation.CENC, DrmLocation.MOOV}
         if la_url is None:
             la_url = urllib.parse.urljoin(
                 flask.request.host_url, flask.url_for('clearkey'))
@@ -63,9 +64,9 @@ class ClearKey(DrmBase):
 
         cenc: CreateDrmData | None = None
         moov: CreateDrmData | None = None
-        if 'cenc' in locations:
+        if DrmLocation.CENC in locations:
             cenc = generate_pssh_box
-        if 'moov' in locations:
+        if DrmLocation.MOOV in locations:
             moov = generate_pssh_box
         return DrmManifestContext(
             system=DrmSystem.CLEARKEY,

--- a/dashlive/drm/clearkey.py
+++ b/dashlive/drm/clearkey.py
@@ -30,9 +30,10 @@ from dashlive.mpeg.mp4 import ContentProtectionSpecificBox
 from dashlive.server.options.container import OptionsContainer
 from dashlive.server.models import Stream
 
-from .base import CreateDrmData, DrmBase, ManifestContext
+from .base import CreateDrmData, DrmBase, DrmManifestContext
 from .keymaterial import KeyMaterial
 from .key_tuple import KeyTuple
+from .system import DrmSystem
 
 class ClearKey(DrmBase):
     MPD_SYSTEM_ID = "e2719d58-a985-b3c9-781a-b030af78d30e"
@@ -48,7 +49,7 @@ class ClearKey(DrmBase):
             options: OptionsContainer,
             la_url: str | None = None,
             https_request: bool = False,
-            locations: AbstractSet[str] | None = None) -> ManifestContext:
+            locations: AbstractSet[str] | None = None) -> DrmManifestContext:
         if locations is None:
             locations = {'cenc', 'moov'}
         if la_url is None:
@@ -66,7 +67,8 @@ class ClearKey(DrmBase):
             cenc = generate_pssh_box
         if 'moov' in locations:
             moov = generate_pssh_box
-        return ManifestContext(
+        return DrmManifestContext(
+            system=DrmSystem.CLEARKEY,
             scheme_id=self.dash_scheme_id(),
             laurl=la_url,
             cenc=cenc,

--- a/dashlive/drm/location.py
+++ b/dashlive/drm/location.py
@@ -1,0 +1,38 @@
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
+
+from enum import Enum
+
+class DrmLocation(Enum):
+    CENC = 'cenc'
+    MOOV = 'moov'
+    PRO = 'pro'
+
+    @classmethod
+    def all(cls) -> list["DrmLocation"]:
+        return [cls[k] for k in cls.keys()]
+
+    @classmethod
+    def keys(cls) -> list[str]:
+        """get list of items in this enum"""
+        return sorted(cls.__members__.keys())  # type: ignore
+
+    @classmethod
+    def values(cls) -> list[str]:
+        """get list of item values in this enum"""
+        return sorted([c.lower() for c in cls.__members__.keys()])  # type: ignore
+
+    @classmethod
+    def from_string(cls, name: str) -> "DrmLocation":
+        """
+        Convert name string into this enum
+        """
+        return cls[name.upper()]  # type: ignore
+
+    def to_json(self) -> str:
+        return self.value

--- a/dashlive/drm/marlin.py
+++ b/dashlive/drm/marlin.py
@@ -26,8 +26,9 @@ from dashlive.mpeg.mp4 import ContentProtectionSpecificBox
 from dashlive.server.models import Stream
 from dashlive.server.options.container import OptionsContainer
 
-from .base import DrmBase, ManifestContext
+from .base import DrmBase, DrmManifestContext
 from .key_tuple import KeyTuple
+from .system import DrmSystem
 
 class Marlin(DrmBase):
     MPD_SYSTEM_ID = '5e629af5-38da-4063-8977-97ffbd9902d4'
@@ -38,12 +39,13 @@ class Marlin(DrmBase):
             options: OptionsContainer,
             la_url: str | None = None,
             https_request: bool = False,
-            locations: AbstractSet[str] | None = None) -> ManifestContext:
+            locations: AbstractSet[str] | None = None) -> DrmManifestContext:
         if la_url is None:
             la_url = options.licenseUrl
             if la_url is None:
                 la_url = stream.marlin_la_url
-        return ManifestContext(
+        return DrmManifestContext(
+            system=DrmSystem.MARLIN,
             laurl=la_url,
             version=0,
             scheme_id=self.dash_scheme_id(),

--- a/dashlive/drm/marlin.py
+++ b/dashlive/drm/marlin.py
@@ -28,6 +28,7 @@ from dashlive.server.options.container import OptionsContainer
 
 from .base import DrmBase, DrmManifestContext
 from .key_tuple import KeyTuple
+from .location import DrmLocation
 from .system import DrmSystem
 
 class Marlin(DrmBase):
@@ -39,7 +40,7 @@ class Marlin(DrmBase):
             options: OptionsContainer,
             la_url: str | None = None,
             https_request: bool = False,
-            locations: AbstractSet[str] | None = None) -> DrmManifestContext:
+            locations: AbstractSet[DrmLocation] | None = None) -> DrmManifestContext:
         if la_url is None:
             la_url = options.licenseUrl
             if la_url is None:

--- a/dashlive/drm/playready.py
+++ b/dashlive/drm/playready.py
@@ -41,9 +41,10 @@ from dashlive.server.models import Stream
 from dashlive.server.options.container import OptionsContainer
 from dashlive.utils.buffered_reader import BufferedReader
 
-from .base import DrmBase, CreateDrmData, CreatePsshBox, ManifestContext
+from .base import DrmBase, CreateDrmData, CreatePsshBox, DrmManifestContext
 from .key_tuple import KeyTuple
 from .keymaterial import KeyMaterial
+from .system import DrmSystem
 
 class PlayReadyRecord(NamedTuple):
     record_type: int
@@ -279,7 +280,7 @@ class PlayReady(DrmBase):
             options: OptionsContainer,
             la_url: str | None = None,
             https_request: bool = False,
-            locations: AbstractSet[str] | None = None) -> ManifestContext:
+            locations: AbstractSet[str] | None = None) -> DrmManifestContext:
 
         if options.version is None:
             header_version = self.minimum_header_version(keys)
@@ -314,7 +315,8 @@ class PlayReady(DrmBase):
             # PlayReady v1.0 (PIFF) mode only allows an mspr:pro element in
             # the manifest
             cenc = generate_pssh_box
-        return ManifestContext(
+        return DrmManifestContext(
+            system=DrmSystem.PLAYREADY,
             laurl=la_url,
             scheme_id=self.dash_scheme_id(version),
             version=version,

--- a/dashlive/drm/system.py
+++ b/dashlive/drm/system.py
@@ -1,0 +1,34 @@
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
+
+from enum import Enum
+
+class DrmSystem(Enum):
+    CLEARKEY = 'clearkey'
+    MARLIN = 'marlin'
+    PLAYREADY = 'playready'
+
+    @classmethod
+    def keys(cls) -> list[str]:
+        """get list of items in this enum"""
+        return sorted(cls.__members__.keys())  # type: ignore
+
+    @classmethod
+    def values(cls) -> list[str]:
+        """get list of item values in this enum"""
+        return sorted([c.lower() for c in cls.__members__.keys()])  # type: ignore
+
+    @classmethod
+    def from_string(cls, name: str) -> "DrmSystem":
+        """
+        Convert name string into this enum
+        """
+        return cls[name.upper()]  # type: ignore
+
+    def to_json(self) -> str:
+        return self.value

--- a/dashlive/management/reset_password.py
+++ b/dashlive/management/reset_password.py
@@ -1,0 +1,50 @@
+#############################################################################
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
+import argparse
+import sys
+
+from dashlive.server.app import create_app
+from dashlive.server.models.db import db
+from dashlive.server.models.user import User
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description='Reset user password')
+    ap.add_argument('--user', help='User name', default='admin')
+    ap.add_argument('password', help='New password')
+    args = ap.parse_args(argv[1:])
+
+    app = create_app(create_default_user=False, wss=False)
+
+    with app.app_context():
+        user = User.get(username=args.user)
+        if user is None:
+            print(f'Unknown user: "{args.user}"')
+            return 1
+        print(f'Setting password for user {args.user}')
+        user.set_password(args.password)
+        user.must_change = True
+        db.session.commit()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/dashlive/mpeg/dash/period.py
+++ b/dashlive/mpeg/dash/period.py
@@ -58,3 +58,16 @@ class Period(ObjectWithFields):
         for adp in self.adaptationSets:
             kids.update(adp.key_ids())
         return kids
+
+    def video_track(self) -> AdaptationSet:
+        for adp in self.adaptationSets:
+            if adp.content_type == 'video':
+                return adp
+        raise AttributeError('Failed to find a video AdaptationSet')
+
+    def audio_tracks(self) -> list[AdaptationSet]:
+        rv: list[AdaptationSet] = []
+        for adp in self.adaptationSets:
+            if adp.content_type == 'audio':
+                rv.append(adp)
+        return rv

--- a/dashlive/server/app.py
+++ b/dashlive/server/app.py
@@ -28,10 +28,10 @@ from pathlib import Path
 import secrets
 
 from dotenv import load_dotenv
-from flask import Flask, request  # type: ignore
+from flask import Flask, request, Response  # type: ignore
 from flask_login import LoginManager
 from flask_socketio import SocketIO
-from werkzeug.routing import BaseConverter  # type: ignore
+from werkzeug.routing import BaseConverter, Map  # type: ignore
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 from dashlive.server import models
@@ -51,11 +51,11 @@ class RegexConverter(BaseConverter):
     """
     Utility class to allow a regex to be used in a route path
     """
-    def __init__(self, url_map, *items):
+    def __init__(self, url_map: Map, *items) -> None:
         super().__init__(url_map)
         self.regex = items[0]
 
-def no_api_cache(response):
+def no_api_cache(response: Response) -> Response:
     """
     Make sure all API calls return no caching directives
     """

--- a/dashlive/server/manifests.py
+++ b/dashlive/server/manifests.py
@@ -120,6 +120,7 @@ class SupportedOptionTupleList:
 
 @dataclass(slots=True, frozen=True)
 class DashManifest:
+    name: str
     title: str
     features: set[str]
     restrictions: dict[str, tuple] | None = field(default_factory=lambda: dict())
@@ -222,6 +223,7 @@ class DashManifest:
 
 manifest = {
     'hand_made.mpd': DashManifest(
+        name='hand_made',
         title='Hand-made manifest',
         features={
             'abr', 'audioCodec', 'useBaseUrls', 'drmSelection', 'eventTypes',
@@ -229,6 +231,7 @@ manifest = {
             'segmentTimeline', 'utcMethod'},
     ),
     'manifest_vod_aiv.mpd': DashManifest(
+        name='manifest_vod_aiv',
         title='AIV on demand profile',
         features={'abr', 'useBaseUrls', 'numPeriods'},
         restrictions={
@@ -238,6 +241,7 @@ manifest = {
         },
     ),
     'manifest_a.mpd': DashManifest(
+        name='manifest_a',
         title='Vendor A live profile',
         features={'abr', 'audioCodec', 'useBaseUrls', 'mode', 'minimumUpdatePeriod',
                   'segmentTimeline'},
@@ -248,6 +252,7 @@ manifest = {
         },
     ),
     'manifest_b.mpd': DashManifest(
+        name='manifest_b',
         title='Vendor B VOD using live profile',
         features={'abr', 'audioCodec', 'useBaseUrls', 'drmSelection'},
         restrictions={
@@ -255,6 +260,7 @@ manifest = {
         },
     ),
     'manifest_e.mpd': DashManifest(
+        name='manifest_e',
         title='Vendor E live profile',
         features={
             'abr', 'audioCodec', 'useBaseUrls', 'drmSelection', 'mode', 'minimumUpdatePeriod',
@@ -264,6 +270,7 @@ manifest = {
         },
     ),
     'manifest_h.mpd': DashManifest(
+        name='manifest_h',
         title='Vendor H live profile',
         features={'abr', 'audioCodec', 'useBaseUrls', 'drmSelection', 'mode',
                   'minimumUpdatePeriod', 'utcMethod'},
@@ -272,6 +279,7 @@ manifest = {
         },
     ),
     'manifest_i.mpd': DashManifest(
+        name='manifest_i',
         title='Vendor I live profile',
         features={'abr', 'useBaseUrls', 'audioCodec', 'drmSelection', 'mode',
                   'minimumUpdatePeriod', 'utcMethod'},
@@ -281,6 +289,7 @@ manifest = {
         },
     ),
     'manifest_ef.mpd': DashManifest(
+        name='manifest_ef',
         title='Vendor EF live profile',
         features={'abr', 'useBaseUrls', 'drmSelection', 'mode'},
         restrictions={
@@ -289,6 +298,7 @@ manifest = {
         },
     ),
     'manifest_n.mpd': DashManifest(
+        name='manifest_n',
         title='Provider N live profile',
         features={'abr', 'audioCodec', 'useBaseUrls', 'drmSelection', 'eventTypes',
                   'mode', 'minimumUpdatePeriod', 'segmentTimeline'},

--- a/dashlive/server/manifests.py
+++ b/dashlive/server/manifests.py
@@ -26,7 +26,7 @@ import logging
 from typing import AbstractSet, Iterator, NamedTuple, Set
 
 from dashlive.mpeg.dash.profiles import primary_profiles
-from dashlive.server.options.drm_options import DrmLocation, DrmSelection
+from dashlive.server.options.drm_options import DrmLocationOption, DrmSelection
 from dashlive.server.options.repository import OptionsRepository
 from dashlive.server.options.types import OptionUsage
 from dashlive.utils.json_object import JsonObject
@@ -203,7 +203,7 @@ class DashManifest:
             if only is not None and opt not in only:
                 continue
             d_opts.append(f'{opt}')
-            for loc in DrmLocation.cgi_choices:
+            for loc in DrmLocationOption.cgi_choices:
                 if loc[1] is None:
                     continue
                 if mode == 'odvod' and 'moov' in loc[1]:

--- a/dashlive/server/options/container.py
+++ b/dashlive/server/options/container.py
@@ -216,7 +216,8 @@ class OptionsContainer(ObjectWithFields):
         todo: list[str] = []
         if mode != 'live':
             todo += {'availabilityStartTime', 'minimumUpdatePeriod',
-                     'timeShiftBufferDepth', 'utcMethod', 'utcValue'}
+                     'ntpSources', 'timeShiftBufferDepth', 'utcMethod',
+                     'utcValue'}
         if encrypted:
             drms = {item[0] for item in self.drmSelection}
             if 'playready' not in drms:

--- a/dashlive/server/options/container.py
+++ b/dashlive/server/options/container.py
@@ -217,7 +217,7 @@ class OptionsContainer(ObjectWithFields):
         if mode != 'live':
             todo += {'availabilityStartTime', 'minimumUpdatePeriod',
                      'ntpSources', 'timeShiftBufferDepth', 'utcMethod',
-                     'utcValue'}
+                     'utcValue', 'patch'}
         if encrypted:
             drms = {item[0] for item in self.drmSelection}
             if 'playready' not in drms:

--- a/dashlive/server/options/repository.py
+++ b/dashlive/server/options/repository.py
@@ -78,7 +78,7 @@ class OptionsRepository:
     def get_cgi_options(cls, use: OptionUsage | None = None,
                         only: AbstractSet[str] | None = None,
                         exclude: AbstractSet[str] | None = None,
-                        extras: DashOption | None = None,
+                        extras: list[DashOption] | None = None,
                         omit_empty: bool = False,
                         **filter) -> list[CgiOption]:
         """
@@ -99,6 +99,8 @@ class OptionsRepository:
         result: list[CgiOption] = []
         todo = cls.get_dash_options(use=use)
         if extras:
+            for e in extras:
+                assert isinstance(e, DashOption)
             todo += extras
         for item in todo:
             if not matches(item):

--- a/dashlive/server/options/utc_time_options.py
+++ b/dashlive/server/options/utc_time_options.py
@@ -41,8 +41,34 @@ UTCValue = DashOption(
     cgi_name='time_value',
     cgi_type='<string>')
 
+NTP_POOLS: dict[str, list[str]] = {
+    'europe-ntp': [
+        '0.europe.pool.ntp.org', '1.europe.pool.ntp.org',
+        '2.europe.pool.ntp.org', '3.europe.pool.ntp.org',
+    ],
+    'google': [
+        'time1.google.com', 'time2.google.com',
+        'time3.google.com', 'time4.google.com',
+    ]
+}
+
+POOL_NAMES: list[str] = sorted(list(NTP_POOLS.keys()))
+
+NTPSources = DashOption(
+    usage=OptionUsage.MANIFEST,
+    short_name='ntps',
+    full_name='ntpSources',
+    title='NTP time servers',
+    description='List of servers to use for NTP requests',
+    from_string=DashOption.list_without_none_from_string,
+    to_string=lambda servers: ','.join(servers),
+    cgi_name='ntp_servers',
+    cgi_type=f'({"|".join(POOL_NAMES)}|<server>,..)',
+    cgi_choices=tuple([None] + POOL_NAMES))
+
 time_options = [
     ClockDrift,
+    NTPSources,
     UTCMethod,
     UTCValue
 ]

--- a/dashlive/server/requesthandler/base.py
+++ b/dashlive/server/requesthandler/base.py
@@ -195,14 +195,6 @@ class RequestHandlerBase(MethodView):
             return default
         return value.lower() in {"1", "true", "on"}
 
-    @staticmethod
-    def drm_locations_for_drm(drm: str) -> set[str]:
-        if drm == 'playready':
-            return {'pro', 'cenc', 'moov'}
-        if drm == 'clearkey':
-            return {'cenc', 'moov'}
-        return {'cenc'}
-
     def calculate_options(self,
                           mode: str,
                           args: dict[str, str],

--- a/dashlive/server/requesthandler/base.py
+++ b/dashlive/server/requesthandler/base.py
@@ -21,15 +21,13 @@
 #############################################################################
 
 from abc import abstractmethod
-import math
-from typing import AbstractSet, Any, NamedTuple, Set, TypeAlias
+from typing import AbstractSet, Any
 
 import base64
 import datetime
 import hashlib
 import hmac
 import logging
-from os import environ
 import re
 import secrets
 import urllib.request
@@ -41,40 +39,15 @@ import flask  # type: ignore
 from flask.views import MethodView  # type: ignore
 from flask_login import current_user
 
-from dashlive.mpeg.dash.adaptation_set import AdaptationSet
-from dashlive.mpeg.dash.patch_location import PatchLocation
-from dashlive.mpeg.dash.period import Period
-from dashlive.mpeg.dash.profiles import primary_profiles, additional_profiles
-from dashlive.mpeg.dash.representation import Representation
-from dashlive.mpeg.dash.timing import DashTiming
-from dashlive.drm.base import DrmBase
-from dashlive.drm.clearkey import ClearKey
-from dashlive.drm.keymaterial import KeyMaterial
-from dashlive.drm.playready import PlayReady
-from dashlive.drm.marlin import Marlin
-from dashlive.server import manifests, models
-from dashlive.server.events.factory import EventFactory
+from dashlive.server import models
 from dashlive.server.routes import routes, Route
 from dashlive.server.options.container import OptionsContainer
 from dashlive.server.options.repository import OptionsRepository
-from dashlive.server.options.types import OptionUsage
 from dashlive.utils import objects
-from dashlive.utils.date_time import scale_timedelta, to_iso_datetime
 from dashlive.utils.json_object import JsonObject
-from dashlive.utils.timezone import UTC
 
-from .decorators import current_stream, is_ajax
 from .exceptions import CsrfFailureException
-
-DrmLocationTuple: TypeAlias = tuple[str, DrmBase, set[str]]
-
-class CgiParameterCollection(NamedTuple):
-    audio: dict[str, str]
-    video: dict[str, str]
-    text: dict[str, str]
-    manifest: dict[str, str]
-    patch: dict[str, str]
-    time: dict[str, str]
+from .utils import is_https_request
 
 class RequestHandlerBase(MethodView):
     CLIENT_COOKIE_NAME = 'dash'
@@ -93,7 +66,7 @@ class RequestHandlerBase(MethodView):
             context["is_current_user_admin"] = current_user.is_admin
         context['remote_addr'] = flask.request.remote_addr
         context['request_uri'] = flask.request.url
-        if self.is_https_request():
+        if is_https_request():
             context['request_uri'] = context['request_uri'].replace(
                 'http://', 'https://')
         return context
@@ -108,7 +81,7 @@ class RequestHandlerBase(MethodView):
             pass
         csrf_key = secrets.token_urlsafe(models.Token.CSRF_KEY_LENGTH)
         secure = None
-        if self.is_https_request:
+        if is_https_request():
             secure = True
 
         @flask.after_this_request
@@ -230,44 +203,6 @@ class RequestHandlerBase(MethodView):
             return {'cenc', 'moov'}
         return {'cenc'}
 
-    def generate_drm_location_tuples(self, options: OptionsContainer) -> list[DrmLocationTuple]:
-        """
-        Returns list of tuples, where each entry is:
-          * DRM name,
-          * DRM implementation, and
-          * DRM data locations
-        """
-        rv = []
-        for drm_name, locations in options.drmSelection:
-            assert drm_name in {'playready', 'marlin', 'clearkey'}
-            if drm_name == 'playready':
-                drm = PlayReady()
-            elif drm_name == 'marlin':
-                drm = Marlin()
-            elif drm_name == 'clearkey':
-                drm = ClearKey()
-            rv.append((drm_name, drm, locations,))
-        return rv
-
-    def generate_drm_dict(self, stream: str | models.Stream,
-                          keys: dict | list, options: OptionsContainer) -> dict:
-        """
-        Generate contexts for all enabled DRM systems. It returns a
-        dictionary with an entry for each DRM system.
-        """
-        if isinstance(stream, str):
-            stream = models.Stream.get(directory=stream)
-            assert stream is not None
-        rv = {}
-        drm_tuples = self.generate_drm_location_tuples(options)
-        for drm_name, drm, locations in drm_tuples:
-            la_url = flask.request.args.get(f'{drm_name}_la_url')
-            rv[drm_name] = drm.generate_manifest_context(
-                stream, keys, getattr(options, drm_name),
-                https_request=self.is_https_request(),
-                la_url=la_url, locations=locations)
-        return rv
-
     def calculate_options(self,
                           mode: str,
                           args: dict[str, str],
@@ -296,349 +231,6 @@ class RequestHandlerBase(MethodView):
         options.add_field('mode', mode)
         return options
 
-    def calculate_manifest_params(self, mpd_name: str,
-                                  options: OptionsContainer,
-                                  stream: models.Stream | None = None) -> dict:
-        if mpd_name is None:
-            raise ValueError("Unable to determin MPD URL")
-        if stream is None:
-            stream = current_stream
-        if not bool(stream):
-            raise ValueError('Stream model is not available')
-        manifest_info = manifests.manifest[mpd_name]
-        now = datetime.datetime.now(tz=UTC())
-        if options.clockDrift:
-            now -= datetime.timedelta(seconds=options.clockDrift)
-        rv = {
-            "minBufferTime": datetime.timedelta(seconds=1.5),
-            "mode": options.mode,
-            "mpd_url": mpd_name,
-            "mpd_id": stream.directory,
-            "now": now,
-            "options": options,
-            "periods": [],
-            'profiles': [primary_profiles[options.mode]],
-            "startNumber": 1,
-            "stream": stream.to_dict(exclude={'media_files'}),
-            "suggestedPresentationDelay": 30,
-            "timing_ref": stream.timing_reference,
-        }
-        if options.mode != 'odvod':
-            rv['profiles'].append(additional_profiles['dvb'])
-        period = Period(start=datetime.timedelta(0), id="p0")
-        audio_adps = self.calculate_audio_adaptation_sets(stream, options)
-        text_adps = self.calculate_text_adaptation_sets(stream, options)
-        max_items = None
-        if options.abr is False:
-            max_items = 1
-        video = self.calculate_video_adaptation_set(stream, options, max_items=max_items)
-
-        timing = DashTiming(now, rv["timing_ref"], options)
-        options.availabilityStartTime = timing.availabilityStartTime
-        options.timeShiftBufferDepth = timing.timeShiftBufferDepth
-        rv.update(timing.generate_manifest_context())
-        cgi_params = self.calculate_cgi_parameters(
-            options=options, now=now, audio=audio_adps, video=video)
-        video.append_cgi_params(cgi_params.video)
-        for audio in audio_adps:
-            audio.append_cgi_params(cgi_params.audio)
-        for text in text_adps:
-            text.append_cgi_params(cgi_params.text)
-        if cgi_params.manifest:
-            locationURL = flask.request.url
-            if '?' in locationURL:
-                locationURL = locationURL[:flask.request.url.index('?')]
-            locationURL = locationURL + objects.dict_to_cgi_params(cgi_params.manifest)
-            rv["locationURL"] = locationURL
-        event_generators = EventFactory.create_event_generators(options)
-        for evgen in event_generators:
-            ev_stream = evgen.create_manifest_context(context=rv)
-            if evgen.inband:
-                # TODO: allow AdaptationSet for inband events to be
-                # configurable
-                video.event_streams.append(ev_stream)
-            else:
-                period.event_streams.append(ev_stream)
-        period.adaptationSets.append(video)
-        period.adaptationSets += audio_adps
-        period.adaptationSets += text_adps
-        if options.patch:
-            patch_loc = flask.url_for(
-                'mpd-patch',
-                stream=stream.directory,
-                manifest=mpd_name.replace('.mpd', ''),
-                publish=int(timing.publishTime.timestamp()))
-            ttl = max(
-                timing.timeShiftBufferDepth,
-                int(math.ceil(timing.minimumUpdatePeriod)))
-            if cgi_params.manifest:
-                patch_loc += objects.dict_to_cgi_params(cgi_params.patch)
-            rv['patch'] = PatchLocation(location=patch_loc, ttl=ttl)
-        prefix = ''
-        if options.useBaseUrls:
-            if options.mode == 'odvod':
-                rv["baseURL"] = urllib.parse.urljoin(
-                    flask.request.host_url, f'/dash/vod/{stream.directory}') + '/'
-            else:
-                rv["baseURL"] = urllib.parse.urljoin(
-                    flask.request.host_url, f'/dash/{options.mode}/{stream.directory}') + '/'
-            if self.is_https_request():
-                rv["baseURL"] = rv["baseURL"].replace('http://', 'https://')
-        else:
-            # convert every initURL and mediaURL to be an absolute URL
-            if options.mode == 'odvod':
-                prefix = flask.url_for(
-                    'dash-od-media',
-                    stream=stream.directory,
-                    filename='RepresentationID',
-                    ext='m4v')
-                prefix = prefix.replace('RepresentationID.m4v', '')
-            else:
-                prefix = flask.url_for(
-                    'dash-media',
-                    mode=options.mode,
-                    stream=stream.directory,
-                    filename='RepresentationID',
-                    segment_num='init',
-                    ext='m4v')
-                prefix = prefix.replace('RepresentationID/init.m4v', '')
-        rv["maxSegmentDuration"] = 0
-        for idx, adp in enumerate(period.adaptationSets):
-            kids: Set[KeyMaterial] = set()
-            adp.id = idx + 1
-            if options.mode != 'odvod':
-                adp.initURL = prefix + adp.initURL
-            adp.mediaURL = prefix + adp.mediaURL
-            adp.set_dash_timing(timing)
-            rv["maxSegmentDuration"] = max(
-                rv["maxSegmentDuration"], adp.maxSegmentDuration)
-            for rep in adp.representations:
-                if rep.encrypted:
-                    kids.update(rep.kids)
-            if adp.encrypted:
-                keys = models.Key.get_kids(kids)
-                adp.drm = self.generate_drm_dict(stream, keys, options)
-                adp.default_kid = list(keys.keys())[0]
-
-        rv["periods"].append(period)
-        rv["kids"] = kids
-        rv["mediaDuration"] = rv["timing_ref"].media_duration_timedelta().total_seconds()
-        rv["timeSource"] = self.choose_time_source_method(options, cgi_params, now)
-        if 'numPeriods' not in manifest_info.features:
-            rv["video"] = video  # TODO: support multiple video tracks
-            rv["audio_sets"] = audio_adps
-            rv["text_sets"] = text_adps
-            rv["period"] = rv["periods"][0]
-        return rv
-
-    def calculate_audio_adaptation_sets(
-            self,
-            stream: models.Stream,
-            options: OptionsContainer,
-            max_items: int | None = None) -> list[AdaptationSet]:
-        adap_sets: dict[int, AdaptationSet] = {}
-        media_files = models.MediaFile.search(
-            content_type='audio', stream=stream, max_items=max_items)
-        audio_files: list[Representation] = []
-        acodec = options.audioCodec
-        for mf in media_files:
-            if mf.representation is None:
-                continue
-            r = mf.representation
-            if r.encrypted != options.encrypted:
-                continue
-            if acodec in {None, 'any'} or r.codecs.startswith(acodec):
-                audio_files.append(r)
-            elif acodec == 'ec-3' and r.codecs == 'ac-3':
-                # special case as CGI paramaters doesn't distinguish between
-                # AC-3 and EAC-3
-                audio_files.append(r)
-        if not audio_files and acodec:
-            # if stream is encrypted but there is no encrypted version of the audio track, fall back
-            # to a clear version
-            for mf in media_files:
-                if mf.representation is None:
-                    continue
-                r = mf.representation
-                if acodec in {None, 'any'} or r.codecs.startswith(acodec):
-                    audio_files.append(r)
-                elif acodec == 'ec-3' and r.codecs == 'ac-3':
-                    # special case as CGI paramaters doesn't distinguish between
-                    # AC-3 and EAC-3
-                    audio_files.append(r)
-
-        for r in audio_files:
-            try:
-                audio = adap_sets[r.track_id]
-            except KeyError:
-                audio = AdaptationSet(
-                    mode=options.mode, content_type='audio', id=(100 + r.track_id),
-                    segment_timeline=options.segmentTimeline, numChannels=r.numChannels)
-                adap_sets[r.track_id] = audio
-            if len(audio_files) == 1 or options.mainAudio == r.id:
-                audio.role = 'main'
-            else:
-                audio.role = 'alternate'
-                if options.audioDescription == r.id:
-                    audio.accessibility = {
-                        'schemeIdUri': "urn:tva:metadata:cs:AudioPurposeCS:2007",
-                        'value': 1,  # Audio description for the visually impaired
-                    }
-            audio.representations.append(r)
-        result: list[AdaptationSet] = []
-        for audio in adap_sets.values():
-            audio.compute_av_values()
-            result.append(audio)
-        return result
-
-    def calculate_video_adaptation_set(
-            self, stream: models.Stream, options: OptionsContainer,
-            max_items: int | None = None) -> AdaptationSet:
-        video = AdaptationSet(
-            mode=options.mode, content_type='video', id=1,
-            segment_timeline=options.segmentTimeline)
-        media_files = models.MediaFile.search(
-            content_type='video', encrypted=options.encrypted, stream=stream,
-            max_items=max_items)
-        for mf in media_files:
-            if mf.representation is None:
-                continue
-            assert mf.content_type == 'video'
-            assert mf.representation.content_type == 'video'
-            video.representations.append(mf.representation)
-        video.compute_av_values()
-        assert isinstance(video.representations, list)
-        return video
-
-    def calculate_text_adaptation_sets(
-            self, stream: models.Stream, options: OptionsContainer,
-            max_items: int | None = None) -> list[AdaptationSet]:
-        media_files = models.MediaFile.search(
-            content_type='text', stream=stream, max_items=max_items)
-        text_tracks: list[Representation] = []
-        for mf in media_files:
-            if mf.representation is None:
-                continue
-            r = mf.representation
-            if r.encrypted == options.encrypted:
-                if options.textCodec is None or r.codecs.startswith(options.textCodec):
-                    text_tracks.append(r)
-        if not text_tracks:
-            # if stream is encrypted but there is no encrypted version of the text track, fall back
-            # to a clear version
-            for mf in media_files:
-                r = mf.representation
-                if options.textCodec is None or r.codecs.startswith(options.textCodec):
-                    text_tracks.append(r)
-        result: list[AdaptationSet] = []
-        for r in text_tracks:
-            text = AdaptationSet(
-                mode=options.mode, content_type='text', id=(200 + r.track_id),
-                segment_timeline=options.segmentTimeline)
-            lang_match = (options.textLanguage is None or
-                          text.lang in {'und', options.textLanguage})
-            if len(text_tracks) == 1 or lang_match:
-                text.role = 'main'
-                # Subtitles for the hard of hearing in the same language as
-                # the programme
-                text.accessibility = {
-                    'schemeIdUri': "urn:tva:metadata:cs:AudioPurposeCS:2007",
-                    'value': 2,
-                }
-            elif options.mainText == r.id:
-                text.role = 'main'
-            else:
-                text.role = 'alternate'
-            text.compute_av_values()
-            result.append(text)
-        return result
-
-    def calculate_cgi_parameters(self, options: OptionsContainer,
-                                 now: datetime.datetime,
-                                 audio: list[AdaptationSet],
-                                 video: AdaptationSet) -> CgiParameterCollection:
-        exclude = {'encrypted', 'mode'}
-        vid_cgi_params = options.generate_cgi_parameters(use=OptionUsage.VIDEO, exclude=exclude)
-        aud_cgi_params = options.generate_cgi_parameters(use=OptionUsage.AUDIO, exclude=exclude)
-        txt_cgi_params = options.generate_cgi_parameters(use=OptionUsage.TEXT, exclude=exclude)
-        mft_cgi_params = options.generate_cgi_parameters(exclude=exclude)
-        patch_cgi_params = options.generate_cgi_parameters(
-            exclude=exclude.union({'timeline', 'patch'}))
-        clk_cgi_params = options.generate_cgi_parameters(use=OptionUsage.TIME, exclude=exclude)
-        if options.videoErrors:
-            times = self.calculate_injected_error_segments(
-                options.videoErrors,
-                now,
-                options.availabilityStartTime,
-                options.timeShiftBufferDepth,
-                video.representations[0])
-            vid_cgi_params['verr'] = times
-        if options.audioErrors and audio:
-            if audio[0].representations:
-                times = self.calculate_injected_error_segments(
-                    options.audioErrors,
-                    now,
-                    options.availabilityStartTime,
-                    options.timeShiftBufferDepth,
-                    audio[0].representations[0])
-                aud_cgi_params['aerr'] = times
-        if options.videoCorruption:
-            errs = [(None, tc) for tc in options.videoCorruption]
-            segs = self.calculate_injected_error_segments(
-                errs,
-                now,
-                options.availabilityStartTime,
-                options.timeShiftBufferDepth,
-                video.representations[0])
-            vid_cgi_params['vcorrupt'] = segs
-        if options.updateCount is not None:
-            mft_cgi_params['update'] = str(options.updateCount + 1)
-
-        return CgiParameterCollection(
-            audio=aud_cgi_params,
-            video=vid_cgi_params,
-            text=txt_cgi_params,
-            manifest=mft_cgi_params,
-            patch=patch_cgi_params,
-            time=clk_cgi_params)
-
-    def choose_time_source_method(self, options: OptionsContainer, cgi_params: dict,
-                                  now: datetime.datetime) -> dict | None:
-        if options.mode != 'live' or options.utcMethod is None:
-            return None
-        format = options.utcMethod
-        value = None
-        if format == 'direct':
-            method = 'urn:mpeg:dash:utc:direct:2014'
-            value = to_iso_datetime(now)
-        elif format == 'head':
-            method = 'urn:mpeg:dash:utc:http-head:2014'
-        elif format == 'http-ntp':
-            method = 'urn:mpeg:dash:utc:http-ntp:2014'
-        elif format == 'iso':
-            method = 'urn:mpeg:dash:utc:http-iso:2014'
-        elif format == 'ntp':
-            method = 'urn:mpeg:dash:utc:ntp:2014'
-            value = 'time1.google.com time2.google.com time3.google.com time4.google.com'
-        elif format == 'sntp':
-            method = 'urn:mpeg:dash:utc:sntp:2014'
-            value = 'time1.google.com time2.google.com time3.google.com time4.google.com'
-        elif format == 'xsd':
-            method = 'urn:mpeg:dash:utc:http-xsdate:2014'
-        else:
-            raise ValueError(fr'Unknown time format: "{format}"')
-        timeSource = {
-            'format': format,
-            'method': method,
-            'value': options.utcValue if options.utcValue is not None else value
-        }
-        if value is None:
-            timeSource['value'] = urllib.parse.urljoin(
-                flask.request.host_url,
-                flask.url_for('time', format=format))
-            timeSource['value'] += objects.dict_to_cgi_params(cgi_params.time)
-        return timeSource
-
     def add_allowed_origins(self, headers):
         cfg = flask.current_app.config['DASH']
         allowed_domains = cfg.get('ALLOWED_DOMAINS', self.DEFAULT_ALLOWED_DOMAINS)
@@ -654,41 +246,6 @@ class RequestHandlerBase(MethodView):
                 headers["Access-Control-Allow-Methods"] = "HEAD, GET, POST"
         except KeyError:
             pass
-
-    def calculate_injected_error_segments(
-            self,
-            errors: list[tuple[int, str]],
-            now: datetime.datetime,
-            availabilityStartTime: datetime.datetime,
-            timeShiftBufferDepth,
-            representation) -> str:
-        """
-        Calculate a list of segment numbers for injecting errors
-        :param errors: a list of error definitions. Each definition is a tuple of an HTTP error
-                       code and either a segment number of an ISO8601 time.
-        :param availabilityStartTime: datetime.datetime containing availability start time
-        :param representation: the Representation to use when calculating segment numbering
-        """
-        drops = []
-        earliest_available = now - \
-            datetime.timedelta(seconds=timeShiftBufferDepth)
-        for item in errors:
-            code, pos = item
-            if isinstance(pos, int):
-                drop_seg = int(pos, 10)
-            else:
-                tm = availabilityStartTime.replace(
-                    hour=pos.hour, minute=pos.minute, second=pos.second)
-                if tm < earliest_available:
-                    continue
-                drop_delta = tm - availabilityStartTime
-                drop_seg = int(scale_timedelta(
-                    drop_delta, representation.timescale, representation.segment_duration))
-            if code is None:
-                drops.append(f'{drop_seg}')
-            else:
-                drops.append(f'{code}={drop_seg}')
-        return urllib.parse.quote_plus(','.join(drops))
 
     def has_http_range(self):
         return 'range' in flask.request.headers
@@ -722,19 +279,6 @@ class RequestHandlerBase(MethodView):
             headers['Content-Range'] = f'bytes */{content_length}'
             status = 416
         return (start, end, status, headers,)
-
-    @staticmethod
-    def is_https_request():
-        if flask.request.scheme == 'https':
-            return True
-        if environ.get('HTTPS', 'off') == 'on':
-            return True
-        if flask.request.headers.get('X-Forwarded-Proto', 'http') == 'https':
-            return True
-        return flask.request.headers.get('X-HTTP-Scheme', 'http') == 'https'
-
-    def is_ajax(self) -> bool:
-        return is_ajax()
 
     def get_next_url(self) -> str | None:
         """

--- a/dashlive/server/requesthandler/cgi_parameter_collection.py
+++ b/dashlive/server/requesthandler/cgi_parameter_collection.py
@@ -1,0 +1,16 @@
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
+from typing import NamedTuple
+
+class CgiParameterCollection(NamedTuple):
+    audio: dict[str, str]
+    video: dict[str, str]
+    text: dict[str, str]
+    manifest: dict[str, str]
+    patch: dict[str, str]
+    time: dict[str, str]

--- a/dashlive/server/requesthandler/decorators.py
+++ b/dashlive/server/requesthandler/decorators.py
@@ -1,3 +1,10 @@
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
 from functools import wraps
 from typing import cast
 
@@ -6,13 +13,7 @@ from flask_login import current_user
 from werkzeug.local import LocalProxy  # type: ignore
 
 from dashlive.server.models import Group, Key, MediaFile, Stream, User
-
-def is_ajax() -> bool:
-    # print('content_type', flask.request.content_type, flask.request.url)
-    return (
-        flask.request.is_json or
-        flask.request.form.get("ajax", "0") == "1" or
-        flask.request.args.get("ajax", "0") == "1")
+from .utils import is_ajax
 
 def needs_login_response(admin: bool, html: bool, permission: Group | None) -> flask.Response:
     if is_ajax():

--- a/dashlive/server/requesthandler/drm_context.py
+++ b/dashlive/server/requesthandler/drm_context.py
@@ -14,6 +14,7 @@ from dashlive.drm.base import DrmBase, DrmManifestContext
 from dashlive.drm.clearkey import ClearKey
 from dashlive.drm.playready import PlayReady
 from dashlive.drm.marlin import Marlin
+from dashlive.drm.system import DrmSystem
 from dashlive.server.models import Stream
 from dashlive.server.options.container import OptionsContainer
 
@@ -68,7 +69,7 @@ class DrmContext:
         """
         rv = []
         for drm_name, locations in options.drmSelection:
-            assert drm_name in {'playready', 'marlin', 'clearkey'}
+            assert drm_name in DrmSystem.values()
             if drm_name == 'playready':
                 drm = PlayReady()
             elif drm_name == 'marlin':

--- a/dashlive/server/requesthandler/drm_context.py
+++ b/dashlive/server/requesthandler/drm_context.py
@@ -1,0 +1,79 @@
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
+
+from typing import TypeAlias
+
+import flask  # type: ignore
+
+from dashlive.drm.base import DrmBase, DrmManifestContext
+from dashlive.drm.clearkey import ClearKey
+from dashlive.drm.playready import PlayReady
+from dashlive.drm.marlin import Marlin
+from dashlive.server.models import Stream
+from dashlive.server.options.container import OptionsContainer
+
+from .utils import is_https_request
+
+DrmLocationTuple: TypeAlias = tuple[str, DrmBase, set[str]]
+
+class DrmContextIterator:
+    contexts: list[DrmManifestContext]
+
+    def __init__(self, manifest_context: dict[str, DrmManifestContext]) -> None:
+        keys: list[str] = list(manifest_context.keys())
+        keys.sort()
+        self.contexts = [manifest_context[k] for k in keys]
+
+    def __next__(self) -> DrmManifestContext:
+        try:
+            return self.contexts.pop(0)
+        except IndexError:
+            raise StopIteration()
+
+
+class DrmContext:
+    manifest_context: dict[str, DrmManifestContext]
+
+    def __init__(self,
+                 stream: str | Stream,
+                 keys: dict | list,
+                 options: OptionsContainer) -> None:
+        self.manifest_context = {}
+        if isinstance(stream, str):
+            stream = Stream.get(directory=stream)
+            assert stream is not None
+        drm_tuples = self.generate_drm_location_tuples(options)
+        for drm_name, drm, locations in drm_tuples:
+            la_url = flask.request.args.get(f'{drm_name}_la_url')
+            self.manifest_context[drm_name] = drm.generate_manifest_context(
+                stream, keys, getattr(options, drm_name),
+                https_request=is_https_request(),
+                la_url=la_url, locations=locations)
+
+    def __iter__(self) -> DrmContextIterator:
+        return DrmContextIterator(self.manifest_context)
+
+    @staticmethod
+    def generate_drm_location_tuples(options: OptionsContainer) -> list[DrmLocationTuple]:
+        """
+        Returns list of tuples, where each entry is:
+          * DRM name,
+          * DRM implementation, and
+          * DRM data locations
+        """
+        rv = []
+        for drm_name, locations in options.drmSelection:
+            assert drm_name in {'playready', 'marlin', 'clearkey'}
+            if drm_name == 'playready':
+                drm = PlayReady()
+            elif drm_name == 'marlin':
+                drm = Marlin()
+            elif drm_name == 'clearkey':
+                drm = ClearKey()
+            rv.append((drm_name, drm, locations,))
+        return rv

--- a/dashlive/server/requesthandler/htmlpage.py
+++ b/dashlive/server/requesthandler/htmlpage.py
@@ -297,13 +297,13 @@ class ViewManifest(HTMLHandlerBase):
 
     decorators = [uses_stream]
 
-    def get(self, mode, stream, manifest, **kwargs):
-        context = self.create_context(**kwargs)
+    def get(self, mode: str, stream: str, manifest: str) -> flask.Response:
+        context = self.create_context(title=current_stream.title)
         try:
             options = self.calculate_options(mode, flask.request.args)
         except ValueError as err:
             logging.error('Invalid CGI parameters: %s', err)
-            return flask.make_response(f'Invalid CGI parameters: {err}', 400)
+            return flask.make_response('Invalid CGI parameters', 400)
         mpd_url = flask.url_for(
             'dash-mpd-v3', stream=stream, manifest=manifest, mode=mode)
         options.remove_unused_parameters(mode, use=~OptionUsage.HTML)

--- a/dashlive/server/requesthandler/htmlpage.py
+++ b/dashlive/server/requesthandler/htmlpage.py
@@ -31,7 +31,7 @@ from flask.views import MethodView  # type: ignore
 from flask_login import current_user
 
 from dashlive.server import manifests, models
-from dashlive.server.options.drm_options import DrmLocation, DrmSelection
+from dashlive.server.options.drm_options import DrmLocationOption, DrmSelection
 from dashlive.server.options.repository import OptionsRepository
 from dashlive.server.options.player_options import ShakaVersion, DashjsVersion
 from dashlive.server.options.types import OptionUsage
@@ -157,7 +157,7 @@ class MainPage(HTMLHandlerBase):
         url = url.replace('/directory/', '/{directory}/')
         url = url.replace('/mode/', '/{mode}/')
         context['url_template'] = url
-        extras = [DrmLocation]
+        extras = [DrmLocationOption]
         cgi_options = OptionsRepository.get_cgi_options(
             featured=True, omit_empty=False, extras=extras)
         for idx, opt in enumerate(cgi_options):

--- a/dashlive/server/requesthandler/htmlpage.py
+++ b/dashlive/server/requesthandler/htmlpage.py
@@ -238,6 +238,7 @@ class VideoPlayer(HTMLHandlerBase):
         if stream_model is None:
             logging.error('Unknown stream: %s', stream)
             return flask.make_response(f'Unknown stream: {html.escape(stream)}', 404)
+        options.remove_unused_parameters(mode)
         dash_parms = ManifestContext(
             manifest=manifests.manifest[manifest], options=options,
             stream=stream_model)

--- a/dashlive/server/requesthandler/keypairs.py
+++ b/dashlive/server/requesthandler/keypairs.py
@@ -29,6 +29,7 @@ from dashlive.server import models
 from .base import HTMLHandlerBase
 from .decorators import login_required, uses_keypair, current_keypair
 from .exceptions import CsrfFailureException
+from .utils import is_ajax
 
 class KeyHandler(HTMLHandlerBase):
     """
@@ -159,7 +160,7 @@ class DeleteKeyHandler(HTMLHandlerBase):
         Returns HTML form to confirm deletion of key pair
         """
         csrf_key = self.generate_csrf_cookie()
-        if self.is_ajax():
+        if is_ajax():
             return self.jsonify({
                 'model': current_keypair.to_dict(),
                 'csrf_token': self.generate_csrf_token('keys', csrf_key),

--- a/dashlive/server/requesthandler/manifest_context.py
+++ b/dashlive/server/requesthandler/manifest_context.py
@@ -1,0 +1,538 @@
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
+import datetime
+import math
+from typing import AbstractSet, NamedTuple, Set, cast
+import urllib.parse
+
+import flask  # type: ignore
+
+from dashlive.drm.keymaterial import KeyMaterial
+from dashlive.mpeg.dash.adaptation_set import AdaptationSet
+from dashlive.mpeg.dash.patch_location import PatchLocation
+from dashlive.mpeg.dash.period import Period
+from dashlive.mpeg.dash.profiles import primary_profiles, additional_profiles
+from dashlive.mpeg.dash.reference import StreamTimingReference
+from dashlive.mpeg.dash.representation import Representation
+from dashlive.mpeg.dash.timing import (
+    DashTiming,
+    DynamicManifestTimingContext,
+    StaticManifestTimingContext,
+)
+from dashlive.server import models
+from dashlive.server.events.factory import EventFactory
+from dashlive.server.manifests import DashManifest
+from dashlive.server.options.container import OptionsContainer
+from dashlive.server.options.types import OptionUsage
+from dashlive.utils import objects
+from dashlive.utils.date_time import scale_timedelta, to_iso_datetime
+from dashlive.utils.json_object import JsonObject
+from dashlive.utils.timezone import UTC
+
+from .decorators import current_stream
+from .drm_context import DrmContext
+from .utils import is_https_request
+
+class CgiParameterCollection(NamedTuple):
+    audio: dict[str, str]
+    video: dict[str, str]
+    text: dict[str, str]
+    manifest: dict[str, str]
+    patch: dict[str, str]
+    time: dict[str, str]
+
+
+class ManifestContext:
+    baseURL: str | None = None
+    cgi_params: CgiParameterCollection
+    locationURL: str
+    manifest: DashManifest | None
+    maxSegmentDuration: int
+    mediaDuration: int
+    minBufferTime: datetime.timedelta
+    mpd_name: str
+    mpd_id: str
+    now: datetime.datetime
+    options: OptionsContainer
+    patch: PatchLocation | None = None
+    periods: list[Period]
+    profiles: list[str]
+    startNumber: int
+    stream: models.Stream
+    suggestedPresentationDelay: int
+    timing_ref: StreamTimingReference | None = None
+    title: str
+
+    def __init__(self,
+                 options: OptionsContainer,
+                 manifest: DashManifest | None = None,
+                 stream: models.Stream | None = None) -> None:
+        if stream is None:
+            stream = current_stream
+        if not bool(stream):
+            raise ValueError('Stream model is not available')
+
+        now = datetime.datetime.now(tz=UTC())
+        if options.clockDrift:
+            now -= datetime.timedelta(seconds=options.clockDrift)
+        self.minBufferTime = datetime.timedelta(seconds=1.5)
+        self.manifest = manifest
+        self.mpd_id = stream.directory
+        self.now = now
+        self.options = options
+        self.maxSegmentDuration = 0
+        self.periods = []
+        self.profiles = [primary_profiles[options.mode]]
+        self.startNumber = 1
+        self.stream = stream  # .to_dict(exclude={'media_files'}),
+        self.suggestedPresentationDelay = 30
+        self.timing_ref = stream.timing_reference
+        self.title = stream.title
+
+        if options.mode != 'odvod':
+            self.profiles.append(additional_profiles['dvb'])
+
+        timing: DashTiming | None = None
+        if self.timing_ref is not None:
+            timing = DashTiming(self.now, self.timing_ref, options)
+            self.mediaDuration = self.timing_ref.media_duration_timedelta().total_seconds()
+
+        self.periods.append(self.create_period(timing))
+        self.timeSource = self.choose_time_source_method(options, self.cgi_params, now)
+        self.finish_periods_setup(timing)
+
+        if options.patch and self.manifest is not None:
+            patch_loc = flask.url_for(
+                'mpd-patch',
+                stream=self.stream.directory,
+                manifest=self.manifest.name,
+                publish=int(timing.publishTime.timestamp()))
+            ttl = max(
+                timing.timeShiftBufferDepth,
+                int(math.ceil(timing.minimumUpdatePeriod)))
+            if self.cgi_params.patch:
+                patch_loc += objects.dict_to_cgi_params(self.cgi_params.patch)
+            self.patch = PatchLocation(location=patch_loc, ttl=ttl)
+
+    def to_dict(self,
+                exclude: AbstractSet[str] | None = None,
+                only: AbstractSet[str] | None = None
+                ) -> JsonObject:
+        retval: JsonObject = {}
+        if exclude is None:
+            exclude = set()
+        for key, value in self.__dict__.items():
+            if only is not None and key not in only:
+                continue
+            if key in exclude:
+                continue
+            retval[key] = value
+        return retval
+
+    @property
+    def period(self) -> Period:
+        if self.periods:
+            return self.periods[0]
+        raise IndexError('periods list is empty')
+
+    @property
+    def video(self) -> AdaptationSet:
+        if not self.periods:
+            raise IndexError('periods list is empty')
+        for adp in self.periods[0].adaptationSets:
+            if adp.content_type == 'video':
+                return adp
+        raise AttributeError('Failed to find a video AdaptationSet')
+
+    @property
+    def audio_sets(self) -> list[AdaptationSet]:
+        rv: list[AdaptationSet] = []
+        if not self.periods:
+            return rv
+        for adp in self.periods[0].adaptationSets:
+            if adp.content_type == 'audio':
+                rv.append(adp)
+        return rv
+
+    @property
+    def text_sets(self) -> list[AdaptationSet]:
+        rv: list[AdaptationSet] = []
+        if not self.periods:
+            return rv
+        for adp in self.periods[0].adaptationSets:
+            if adp.content_type == 'text':
+                rv.append(adp)
+        return rv
+
+    def create_period(self, timing: DashTiming | None) -> Period:
+        opts = self.options
+
+        period = Period(start=datetime.timedelta(0), id="p0")
+        audio_adps = self.calculate_audio_adaptation_sets()
+        text_adps = self.calculate_text_adaptation_sets()
+        max_items = None
+        if opts.abr is False:
+            max_items = 1
+        video = self.calculate_video_adaptation_set(max_items=max_items)
+
+        if timing:
+            opts.availabilityStartTime = timing.availabilityStartTime
+            opts.timeShiftBufferDepth = timing.timeShiftBufferDepth
+            self.update_timing(timing)
+
+        self.cgi_params = self.calculate_cgi_parameters(
+            audio=audio_adps, video=video)
+        video.append_cgi_params(self.cgi_params.video)
+        for audio in audio_adps:
+            audio.append_cgi_params(self.cgi_params.audio)
+        for text in text_adps:
+            text.append_cgi_params(self.cgi_params.text)
+        if self.cgi_params.manifest:
+            locationURL = flask.request.url
+            if '?' in locationURL:
+                locationURL = locationURL[:flask.request.url.index('?')]
+            locationURL = locationURL + objects.dict_to_cgi_params(self.cgi_params.manifest)
+            self.locationURL = locationURL
+        event_generators = EventFactory.create_event_generators(opts)
+        for evgen in event_generators:
+            ev_stream = evgen.create_manifest_context(context=vars(self))
+            if evgen.inband:
+                # TODO: allow AdaptationSet for inband events to be
+                # configurable
+                video.event_streams.append(ev_stream)
+            else:
+                period.event_streams.append(ev_stream)
+        period.adaptationSets.append(video)
+        period.adaptationSets += audio_adps
+        period.adaptationSets += text_adps
+        return period
+
+    def calculate_video_adaptation_set(
+            self, max_items: int | None = None) -> AdaptationSet:
+        video = AdaptationSet(
+            mode=self.options.mode, content_type='video', id=1,
+            segment_timeline=self.options.segmentTimeline)
+        media_files = models.MediaFile.search(
+            content_type='video', encrypted=self.options.encrypted,
+            stream=self.stream, max_items=max_items)
+        for mf in media_files:
+            if mf.representation is None:
+                continue
+            assert mf.content_type == 'video'
+            assert mf.representation.content_type == 'video'
+            video.representations.append(mf.representation)
+        video.compute_av_values()
+        assert isinstance(video.representations, list)
+        return video
+
+    def calculate_audio_adaptation_sets(
+            self, max_items: int | None = None) -> list[AdaptationSet]:
+        opts = self.options
+        adap_sets: dict[int, AdaptationSet] = {}
+        media_files = models.MediaFile.search(
+            content_type='audio', stream=self.stream, max_items=max_items)
+        audio_files: list[Representation] = []
+        acodec = opts.audioCodec
+        for mf in media_files:
+            if mf.representation is None:
+                continue
+            r = mf.representation
+            if r.encrypted != opts.encrypted:
+                continue
+            if acodec in {None, 'any'} or r.codecs.startswith(acodec):
+                audio_files.append(r)
+            elif acodec == 'ec-3' and r.codecs == 'ac-3':
+                # special case as CGI paramaters doesn't distinguish between
+                # AC-3 and EAC-3
+                audio_files.append(r)
+        if not audio_files and acodec:
+            # if stream is encrypted but there is no encrypted version of the audio track, fall back
+            # to a clear version
+            for mf in media_files:
+                if mf.representation is None:
+                    continue
+                r = mf.representation
+                if acodec in {None, 'any'} or r.codecs.startswith(acodec):
+                    audio_files.append(r)
+                elif acodec == 'ec-3' and r.codecs == 'ac-3':
+                    # special case as CGI paramaters doesn't distinguish between
+                    # AC-3 and EAC-3
+                    audio_files.append(r)
+
+        for r in audio_files:
+            try:
+                audio = adap_sets[r.track_id]
+            except KeyError:
+                audio = AdaptationSet(
+                    mode=opts.mode, content_type='audio',
+                    id=(100 + r.track_id),
+                    segment_timeline=opts.segmentTimeline,
+                    numChannels=r.numChannels)
+                adap_sets[r.track_id] = audio
+            if len(audio_files) == 1 or opts.mainAudio == r.id:
+                audio.role = 'main'
+            else:
+                audio.role = 'alternate'
+                if opts.audioDescription == r.id:
+                    audio.accessibility = {
+                        'schemeIdUri': "urn:tva:metadata:cs:AudioPurposeCS:2007",
+                        'value': 1,  # Audio description for the visually impaired
+                    }
+            audio.representations.append(r)
+        result: list[AdaptationSet] = []
+        for audio in adap_sets.values():
+            audio.compute_av_values()
+            result.append(audio)
+        return result
+
+    def calculate_text_adaptation_sets(
+            self, max_items: int | None = None) -> list[AdaptationSet]:
+        opts = self.options
+
+        media_files = models.MediaFile.search(
+            content_type='text', stream=self.stream, max_items=max_items)
+        text_tracks: list[Representation] = []
+        for mf in media_files:
+            if mf.representation is None:
+                continue
+            r = mf.representation
+            if r.encrypted == opts.encrypted:
+                if opts.textCodec is None or r.codecs.startswith(
+                        opts.textCodec):
+                    text_tracks.append(r)
+        if not text_tracks:
+            # if stream is encrypted but there is no encrypted version of the text track, fall back
+            # to a clear version
+            for mf in media_files:
+                r = mf.representation
+                if opts.textCodec is None or r.codecs.startswith(
+                        opts.textCodec):
+                    text_tracks.append(r)
+        result: list[AdaptationSet] = []
+        for r in text_tracks:
+            text = AdaptationSet(
+                mode=opts.mode, content_type='text',
+                id=(200 + r.track_id),
+                segment_timeline=opts.segmentTimeline)
+            lang_match = (opts.textLanguage is None or
+                          text.lang in {'und', opts.textLanguage})
+            if len(text_tracks) == 1 or lang_match:
+                text.role = 'main'
+                # Subtitles for the hard of hearing in the same language as
+                # the programme
+                text.accessibility = {
+                    'schemeIdUri': "urn:tva:metadata:cs:AudioPurposeCS:2007",
+                    'value': 2,
+                }
+            elif opts.mainText == r.id:
+                text.role = 'main'
+            else:
+                text.role = 'alternate'
+            text.compute_av_values()
+            result.append(text)
+        return result
+
+    def calculate_cgi_parameters(
+            self,
+            audio: list[AdaptationSet],
+            video: AdaptationSet) -> CgiParameterCollection:
+        exclude = {'encrypted', 'mode'}
+        options = self.options
+
+        vid_cgi_params = options.generate_cgi_parameters(
+            use=OptionUsage.VIDEO, exclude=exclude)
+        aud_cgi_params = options.generate_cgi_parameters(
+            use=OptionUsage.AUDIO, exclude=exclude)
+        txt_cgi_params = options.generate_cgi_parameters(
+            use=OptionUsage.TEXT, exclude=exclude)
+        mft_cgi_params = options.generate_cgi_parameters(exclude=exclude)
+        patch_cgi_params = options.generate_cgi_parameters(
+            exclude=exclude.union({'timeline', 'patch'}))
+        clk_cgi_params = options.generate_cgi_parameters(
+            use=OptionUsage.TIME, exclude=exclude)
+
+        if options.videoErrors:
+            times = self.calculate_injected_error_segments(
+                options.videoErrors,
+                self.now,
+                options.availabilityStartTime,
+                options.timeShiftBufferDepth,
+                video.representations[0])
+            vid_cgi_params['verr'] = times
+
+        if options.audioErrors and audio:
+            if audio[0].representations:
+                times = self.calculate_injected_error_segments(
+                    options.audioErrors,
+                    self.now,
+                    options.availabilityStartTime,
+                    options.timeShiftBufferDepth,
+                    audio[0].representations[0])
+                aud_cgi_params['aerr'] = times
+
+        if options.videoCorruption:
+            errs = [(None, tc) for tc in options.videoCorruption]
+            segs = self.calculate_injected_error_segments(
+                errs,
+                self.now,
+                options.availabilityStartTime,
+                options.timeShiftBufferDepth,
+                video.representations[0])
+            vid_cgi_params['vcorrupt'] = segs
+
+        if options.updateCount is not None:
+            mft_cgi_params['update'] = str(options.updateCount + 1)
+
+        return CgiParameterCollection(
+            audio=aud_cgi_params,
+            video=vid_cgi_params,
+            text=txt_cgi_params,
+            manifest=mft_cgi_params,
+            patch=patch_cgi_params,
+            time=clk_cgi_params)
+
+    def finish_periods_setup(self, timing: DashTiming | None) -> None:
+        prefix: str = ''
+        base: str
+        if self.options.mode == 'odvod':
+            base = flask.url_for(
+                'dash-od-media',
+                stream=self.stream.directory,
+                filename='RepresentationID',
+                ext='m4v')
+            base = base.replace('RepresentationID.m4v', '')
+        else:
+            base = flask.url_for(
+                'dash-media',
+                mode=self.options.mode,
+                stream=self.stream.directory,
+                filename='RepresentationID',
+                segment_num='init',
+                ext='m4v')
+            base = base.replace('RepresentationID/init.m4v', '')
+        if self.options.useBaseUrls:
+            self.baseURL = urllib.parse.urljoin(flask.request.host_url, base)
+            if is_https_request():
+                self.baseURL = self.baseURL.replace('http://', 'https://')
+        else:
+            # convert every initURL and mediaURL to be an absolute URL
+            prefix = base
+
+        for period in self.periods:
+            for idx, adp in enumerate(period.adaptationSets):
+                kids: Set[KeyMaterial] = set()
+                adp.id = idx + 1  # is this needed?
+                if prefix:
+                    if self.options.mode != 'odvod':
+                        adp.initURL = prefix + adp.initURL
+                    adp.mediaURL = prefix + adp.mediaURL
+                if timing:
+                    adp.set_dash_timing(timing)
+                self.maxSegmentDuration = max(
+                    self.maxSegmentDuration, adp.maxSegmentDuration)
+                for rep in adp.representations:
+                    if rep.encrypted:
+                        kids.update(rep.kids)
+                if adp.encrypted:
+                    keys = models.Key.get_kids(kids)
+                    dc = DrmContext(self.stream, keys, self.options)
+                    adp.drm = dc.manifest_context
+                    adp.default_kid = list(keys.keys())[0]
+
+    @staticmethod
+    def calculate_injected_error_segments(
+            errors: list[tuple[int, str]],
+            now: datetime.datetime,
+            availabilityStartTime: datetime.datetime,
+            timeShiftBufferDepth: int,
+            representation: Representation) -> str:
+        """
+        Calculate a list of segment numbers for injecting errors
+        :param errors: a list of error definitions. Each definition is a
+            tuple of an HTTP error code and either a segment number or
+            an ISO8601 time.
+        :param availabilityStartTime: datetime.datetime containing
+            availability start time
+        :param representation: the Representation to use when calculating
+            segment numbering
+        """
+        drops = []
+        earliest_available = now - datetime.timedelta(
+            seconds=timeShiftBufferDepth)
+        for item in errors:
+            code, pos = item
+            if isinstance(pos, int):
+                drop_seg = int(pos, 10)
+            else:
+                tm = availabilityStartTime.replace(
+                    hour=pos.hour, minute=pos.minute, second=pos.second)
+                if tm < earliest_available:
+                    continue
+                drop_delta = tm - availabilityStartTime
+                drop_seg = int(scale_timedelta(
+                    drop_delta, representation.timescale,
+                    representation.segment_duration))
+            if code is None:
+                drops.append(f'{drop_seg}')
+            else:
+                drops.append(f'{code}={drop_seg}')
+        return urllib.parse.quote_plus(','.join(drops))
+
+    def update_timing(self, timing: DashTiming) -> None:
+        tc = timing.generate_manifest_context()
+        self.now = tc.now
+        self.publishTime = tc.publishTime
+        if self.options.mode != 'live':
+            stc = cast(StaticManifestTimingContext, tc)
+            self.mediaDuration = stc.mediaDuration
+            return
+        ltc = cast(DynamicManifestTimingContext, tc)
+        self.availabilityStartTime = ltc.availabilityStartTime
+        self.elapsedTime = ltc.elapsedTime
+        self.minimumUpdatePeriod = ltc.minimumUpdatePeriod
+        self.timeShiftBufferDepth = ltc.timeShiftBufferDepth
+
+    @staticmethod
+    def choose_time_source_method(options: OptionsContainer,
+                                  cgi_params: CgiParameterCollection,
+                                  now: datetime.datetime) -> dict | None:
+        # TODO: replace dict with NamedTuple
+        if options.mode != 'live' or options.utcMethod is None:
+            return None
+        format = options.utcMethod
+        value = None
+        if format == 'direct':
+            method = 'urn:mpeg:dash:utc:direct:2014'
+            value = to_iso_datetime(now)
+        elif format == 'head':
+            method = 'urn:mpeg:dash:utc:http-head:2014'
+        elif format == 'http-ntp':
+            method = 'urn:mpeg:dash:utc:http-ntp:2014'
+        elif format == 'iso':
+            method = 'urn:mpeg:dash:utc:http-iso:2014'
+        elif format == 'ntp':
+            method = 'urn:mpeg:dash:utc:ntp:2014'
+            value = 'time1.google.com time2.google.com time3.google.com time4.google.com'
+        elif format == 'sntp':
+            method = 'urn:mpeg:dash:utc:sntp:2014'
+            value = 'time1.google.com time2.google.com time3.google.com time4.google.com'
+        elif format == 'xsd':
+            method = 'urn:mpeg:dash:utc:http-xsdate:2014'
+        else:
+            raise ValueError(fr'Unknown time format: "{format}"')
+        timeSource = {
+            'format': format,
+            'method': method,
+            'value': options.utcValue if options.utcValue is not None else value
+        }
+        if value is None:
+            timeSource['value'] = urllib.parse.urljoin(
+                flask.request.host_url,
+                flask.url_for('time', format=format))
+            timeSource['value'] += objects.dict_to_cgi_params(cgi_params.time)
+        return timeSource

--- a/dashlive/server/requesthandler/manifest_context.py
+++ b/dashlive/server/requesthandler/manifest_context.py
@@ -102,7 +102,11 @@ class ManifestContext:
             self.timeSource = TimeSourceContext(self.options, self.cgi_params, now)
         self.finish_periods_setup(timing)
 
-        if options.patch and self.manifest is not None:
+        if (
+                self.options.mode == 'live' and
+                options.patch and
+                self.manifest is not None and
+                timing is not None):
             patch_loc = flask.url_for(
                 'mpd-patch',
                 stream=self.stream.directory,

--- a/dashlive/server/requesthandler/manifest_requests.py
+++ b/dashlive/server/requesthandler/manifest_requests.py
@@ -35,6 +35,7 @@ from dashlive.utils.timezone import UTC
 
 from .base import RequestHandlerBase
 from .decorators import uses_stream, current_stream
+from .manifest_context import ManifestContext
 
 class ServeManifest(RequestHandlerBase):
     """handler for generating MPD files"""
@@ -84,9 +85,8 @@ class ServeManifest(RequestHandlerBase):
         elif mft.segment_timeline or options.patch:
             options.update(segmentTimeline=True)
         options.remove_unused_parameters(mode)
-        context['options'] = options
-        dash = self.calculate_manifest_params(mpd_name=manifest, options=options)
-        context.update(dash)
+        dash = ManifestContext(manifest=mft, options=options)
+        context.update(dash.to_dict())
         response = self.check_for_synthetic_manifest_error(options, context)
         if response is not None:
             return response
@@ -228,9 +228,8 @@ class ServePatch(RequestHandlerBase):
             'options': options,
             'original_publish_time': original_publish_time,
         })
-        dash = self.calculate_manifest_params(
-            mpd_name=f'{manifest}.mpd', options=options)
-        context.update(dash)
+        dash = ManifestContext(manifest=mft, options=options)
+        context.update(dash.to_dict())
 
         body = flask.render_template(f'patches/{manifest}.xml', **context)
         try:

--- a/dashlive/server/requesthandler/time_source_context.py
+++ b/dashlive/server/requesthandler/time_source_context.py
@@ -1,0 +1,54 @@
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
+import datetime
+import urllib.parse
+
+import flask  # type: ignore
+
+from dashlive.server.options.container import OptionsContainer
+from dashlive.utils.date_time import to_iso_datetime
+from dashlive.utils.objects import dict_to_cgi_params
+
+from .cgi_parameter_collection import CgiParameterCollection
+
+class TimeSourceContext:
+    method: str
+    schemeIdUri: str
+    value: str | None
+
+    def __init__(self,
+                 options: OptionsContainer,
+                 cgi_params: CgiParameterCollection,
+                 now: datetime.datetime) -> None:
+        self.method = options.utcMethod
+        self.value = None
+        if self.method == 'direct':
+            self.schemeIdUri = 'urn:mpeg:dash:utc:direct:2014'
+            self.value = to_iso_datetime(now)
+        elif self.method == 'head':
+            self.schemeIdUri = 'urn:mpeg:dash:utc:http-head:2014'
+        elif self.method == 'http-ntp':
+            self.schemeIdUri = 'urn:mpeg:dash:utc:http-ntp:2014'
+        elif self.method == 'iso':
+            self.schemeIdUri = 'urn:mpeg:dash:utc:http-iso:2014'
+        elif self.method == 'ntp':
+            self.schemeIdUri = 'urn:mpeg:dash:utc:ntp:2014'
+            self.value = 'time1.google.com time2.google.com time3.google.com time4.google.com'
+        elif self.method == 'sntp':
+            self.schemeIdUri = 'urn:mpeg:dash:utc:sntp:2014'
+            self.value = 'time1.google.com time2.google.com time3.google.com time4.google.com'
+        elif self.method == 'xsd':
+            self.schemeIdUri = 'urn:mpeg:dash:utc:http-xsdate:2014'
+        else:
+            raise ValueError(fr'Unknown time method: "{self.method}"')
+
+        if self.value is None:
+            self.value = urllib.parse.urljoin(
+                flask.request.host_url,
+                flask.url_for('time', method=self.method))
+            self.value += dict_to_cgi_params(cgi_params.time)

--- a/dashlive/server/requesthandler/utctime.py
+++ b/dashlive/server/requesthandler/utctime.py
@@ -32,15 +32,15 @@ from dashlive.utils.timezone import UTC
 from .base import RequestHandlerBase
 
 class UTCTimeHandler(RequestHandlerBase):
-    def head(self, format, **kwargs):
-        return self.get(format, **kwargs)
+    def head(self, method: str) -> flask.Response:
+        return self.get(method)
 
-    def get(self, format, **kwargs):
+    def get(self, method: str) -> flask.Response:
         try:
             options = self.calculate_options('live', flask.request.args)
         except ValueError as err:
             logging.error('Invalid CGI parameters: %s', err)
-            return flask.make_response(f'Invalid CGI parameters: {err}', 400)
+            return flask.make_response('Invalid CGI parameters', 400)
         now = datetime.datetime.now(tz=UTC())
         if options.clockDrift:
             now -= datetime.timedelta(seconds=options.clockDrift)
@@ -49,15 +49,15 @@ class UTCTimeHandler(RequestHandlerBase):
             'Date': now.strftime(r'%a, %d %b %Y %H:%M:%S %Z'),
         }
         rv = ''
-        if format == 'xsd':
+        if method == 'xsd':
             rv = to_iso_datetime(now)
-        elif format == 'iso':
+        elif method == 'iso':
             # This code picks an obscure option from ISO 8601, so that a simple parser
             # will fail
             isocal = now.isocalendar()
             rv = '%04d-W%02d-%dT%02d:%02d:%02dZ' % (
                 isocal[0], isocal[1], isocal[2], now.hour, now.minute, now.second)
-        elif format == 'http-ntp':
+        elif method == 'http-ntp':
             # NTP epoch is 1st Jan 1900
             epoch = datetime.datetime(
                 year=1900, month=1, day=1, tzinfo=UTC())

--- a/dashlive/server/requesthandler/utils.py
+++ b/dashlive/server/requesthandler/utils.py
@@ -1,0 +1,25 @@
+#############################################################################
+#
+#  Project Name        :    Simulated MPEG DASH service
+#
+#  Author              :    Alex Ashley
+#
+#############################################################################
+from os import environ
+
+import flask  # type: ignore
+
+def is_ajax() -> bool:
+    return (
+        flask.request.is_json or
+        flask.request.form.get("ajax", "0") == "1" or
+        flask.request.args.get("ajax", "0") == "1")
+
+def is_https_request() -> bool:
+    if flask.request.scheme == 'https':
+        return True
+    if environ.get('HTTPS', 'off') == 'on':
+        return True
+    if flask.request.headers.get('X-Forwarded-Proto', 'http') == 'https':
+        return True
+    return flask.request.headers.get('X-HTTP-Scheme', 'http') == 'https'

--- a/dashlive/server/routes.py
+++ b/dashlive/server/routes.py
@@ -138,7 +138,7 @@ routes = {
         handler='streams.ListStreams',
         title='Available DASH streams'),
     "time": Route(
-        r'/time/<regex("(head|xsd|iso|http-ntp)"):format>',
+        r'/time/<regex("(head|xsd|iso|http-ntp)"):method>',
         handler='utctime.UTCTimeHandler',
         title='Current time of day'),
     "delete-stream": Route(

--- a/dashlive/server/template_tags.py
+++ b/dashlive/server/template_tags.py
@@ -160,6 +160,16 @@ def toHtmlString(item, className=None):
             rv = str(rv)
     return HtmlSafeString(rv)
 
+def json_encoder(value: Any) -> Any:
+    if isinstance(value, set):
+        lst = list(value)
+        lst.sort()
+        return lst
+    to_json = getattr(value, 'to_json', None)
+    if to_json and callable(to_json):
+        return value.to_json()
+    raise TypeError(f'Unable to encode value of type {type(value)}')
+
 @custom_tags.app_template_filter()
 def toJson(value, indent: int | None = None):
     if value is None:
@@ -167,7 +177,7 @@ def toJson(value, indent: int | None = None):
     try:
         if isinstance(value, (dict, list, set, tuple)):
             value = flatten_iterable(value)
-        return json.dumps(value, indent=indent)
+        return json.dumps(value, indent=indent, default=json_encoder)
     except ValueError as err:
         return str(err)
 

--- a/templates/manifest.html
+++ b/templates/manifest.html
@@ -12,7 +12,7 @@
         MPD URL:
       </label>
       <div class="col-11">
-        <input type="text" value="{{ mpd_url }}" name="mpd_url" id="id_mpd_url" class="form-control" />
+        <input type="text" value="{{ mpd_url|safe }}" name="mpd_url" id="id_mpd_url" class="form-control" />
       </div>
     </div>
   </form>
@@ -38,7 +38,7 @@ $('#mpd-form').on('submit', function(ev) {
     });
 });
 
-$.ajax("{{ mpd_url }}", {
+$.ajax("{{ mpd_url|safe }}", {
     success: displayMpd,
     dataType: "xml",
 });

--- a/templates/manifests/hand_made.mpd
+++ b/templates/manifests/hand_made.mpd
@@ -29,7 +29,7 @@
  </ProgramInformation>
  <Location>{{ request_uri|xmlSafe }}</Location>
  {%- if mpd.timeSource %}
- <UTCTiming schemeIdUri="{{mpd.timeSource.method}}" value="{{mpd.timeSource.value}}"/>
+ <UTCTiming schemeIdUri="{{mpd.timeSource.schemeIdUri}}" value="{{mpd.timeSource.value}}"/>
  {% endif %}
  {%- if options.patch %}
    <PatchLocation ttl="{{ mpd.patch.ttl }}">{{ mpd.patch.location|xmlSafe }}</PatchLocation>

--- a/templates/manifests/hand_made.mpd
+++ b/templates/manifests/hand_made.mpd
@@ -30,7 +30,7 @@
  <Location>{{ request_uri|xmlSafe }}</Location>
  {%- if mpd.timeSource %}
  <UTCTiming schemeIdUri="{{mpd.timeSource.schemeIdUri}}" value="{{mpd.timeSource.value}}"/>
- {% endif %}
+ {% endif -%}
  {%- if options.patch %}
    <PatchLocation ttl="{{ mpd.patch.ttl }}">{{ mpd.patch.location|xmlSafe }}</PatchLocation>
  {% endif -%}

--- a/templates/manifests/hand_made.mpd
+++ b/templates/manifests/hand_made.mpd
@@ -3,42 +3,44 @@
      xmlns:cenc="urn:mpeg:cenc:2013"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
-     publishTime="{{publishTime|isoDateTime}}"
-     id="{{ mpd_id }}"
-  {%- if mode=='live' %}
+     publishTime="{{ mpd.publishTime|isoDateTime }}"
+     id="{{ mpd.mpd_id }}"
+  {%- if mode == 'live' %}
     type="dynamic"
-    {%- if minimumUpdatePeriod %}
-    minimumUpdatePeriod="{{minimumUpdatePeriod|isoDuration}}"
+    {%- if mpd.minimumUpdatePeriod %}
+    minimumUpdatePeriod="{{ mpd.minimumUpdatePeriod|isoDuration }}"
     {%- endif %}
-    {%- if suggestedPresentationDelay %}
-    suggestedPresentationDelay="{{suggestedPresentationDelay|isoDuration}}"
+    {%- if mpd.suggestedPresentationDelay %}
+    suggestedPresentationDelay="{{ mpd.suggestedPresentationDelay|isoDuration}}"
     {%- endif %}
-    availabilityStartTime="{{availabilityStartTime|isoDateTime}}"
-    timeShiftBufferDepth="{{timeShiftBufferDepth|isoDuration}}"
+    availabilityStartTime="{{ mpd.availabilityStartTime|isoDateTime }}"
+    timeShiftBufferDepth="{{ mpd.timeShiftBufferDepth|isoDuration }}"
   {%- else %}
     type="static"
   {%- endif %}
-  {%- if mode!='live' %}
-    mediaPresentationDuration="{{mediaDuration|isoDuration}}"
+  {%- if mode != 'live' %}
+    mediaPresentationDuration="{{ mpd.mediaDuration|isoDuration }}"
   {%- endif %}
-  profiles="{{ profiles | join(',') }}"
-  minBufferTime="{{minBufferTime|isoDuration}}"
+  profiles="{{ mpd.profiles | join(',') }}"
+  minBufferTime="{{ mpd.minBufferTime|isoDuration }}"
 >
  <ProgramInformation>
-  <Title>{{title}}</Title>
+  <Title>{{ title }} </Title>
  </ProgramInformation>
- <Location>{{request_uri|xmlSafe}}</Location>
- {%- if timeSource %}<UTCTiming schemeIdUri="{{timeSource.method}}" value="{{timeSource.value}}"/>{% endif %}
+ <Location>{{ request_uri|xmlSafe }}</Location>
+ {%- if mpd.timeSource %}
+ <UTCTiming schemeIdUri="{{mpd.timeSource.method}}" value="{{mpd.timeSource.value}}"/>
+ {% endif %}
  {%- if options.patch %}
-   <PatchLocation ttl="{{ patch.ttl }}">{{ patch.location|xmlSafe }}</PatchLocation>
+   <PatchLocation ttl="{{ mpd.patch.ttl }}">{{ mpd.patch.location|xmlSafe }}</PatchLocation>
  {% endif -%}
- {%- for period in periods %}
+ {%- for period in mpd.periods %}
    <Period
      start="{{period.start|isoDuration}}"
      id="{{ period.id }}"
      {%- if period.duration %}duration="{{period.duration|isoDuration}}"{% endif %}
    >
-     {%- if baseURL %}<BaseURL>{{baseURL}}</BaseURL>{% endif %}
+     {%- if mpd.baseURL %}<BaseURL>{{ mpd.baseURL }}</BaseURL>{% endif %}
      {% include "events/period.xml" %}
      {%- for adp in period.adaptationSets %}
        <AdaptationSet

--- a/templates/manifests/manifest_a.mpd
+++ b/templates/manifests/manifest_a.mpd
@@ -3,40 +3,42 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="urn:mpeg:dash:schema:mpd:2011"
   xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
-  {% if mode=='live' %}
+  {%- if mode=='live' %}
   type="dynamic"
-  availabilityStartTime="{{availabilityStartTime|isoDateTime}}"
-  {% if minimumUpdatePeriod %}minimumUpdatePeriod="{{minimumUpdatePeriod|isoDuration}}"{% endif %}
-  timeShiftBufferDepth="{{timeShiftBufferDepth|isoDuration}}"
+  availabilityStartTime="{{ mpd.availabilityStartTime|isoDateTime }}"
+  {%- if mpd.minimumUpdatePeriod %}
+  minimumUpdatePeriod="{{ mpd.minimumUpdatePeriod|isoDuration }}"
+  {%- endif %}
+  timeShiftBufferDepth="{{ mpd.timeShiftBufferDepth|isoDuration }}"
   {% else %}
   type="static"
-  mediaPresentationDuration="{{mediaDuration|isoDuration}}"
-  {% endif %}  
-  publishTime="{{publishTime|isoDateTime}}"
-  maxSegmentDuration="{{maxSegmentDuration|isoDuration}}"
+  mediaPresentationDuration="{{ mpd.mediaDuration|isoDuration }}"
+  {%- endif %}  
+  publishTime="{{ mpd.publishTime|isoDateTime }}"
+  maxSegmentDuration="{{ mpd.maxSegmentDuration|isoDuration }}"
   minBufferTime="PT10S"
   profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:com:dashif:dash264,urn:hbbtv:dash:profile:isoff-live:2012">
   <Period
     id="1"
     start="PT0S">
-    {% if baseURL %}<BaseURL>{{baseURL}}</BaseURL>{% endif %}
+    {% if mpd.baseURL %}<BaseURL>{{ mpd.baseURL }}</BaseURL>{% endif %}
     <AdaptationSet
       group="2"
       mimeType="video/mp4"
       par="16:9"
-      minBandwidth="{{video.minBitrate}}"
-      maxBandwidth="{{video.maxBitrate}}"
-      minWidth="{{video.minWidth}}"
-      maxWidth="{{video.maxWidth}}"
-      minHeight="{{video.minHeight}}"
-      maxHeight="{{video.maxHeight}}"
+      minBandwidth="{{mpd.video.minBitrate}}"
+      maxBandwidth="{{mpd.video.maxBitrate}}"
+      minWidth="{{mpd.video.minWidth}}"
+      maxWidth="{{mpd.video.maxWidth}}"
+      minHeight="{{mpd.video.minHeight}}"
+      maxHeight="{{mpd.video.maxHeight}}"
       segmentAlignment="true"
       startWithSAP="1">
-      {% for rep in video.representations %}
+      {% for rep in mpd.video.representations %}
       {% if loop.first %}
       <SegmentTemplate timescale="{{rep.timescale}}"
-              initialization="{{video.initURL|xmlSafe}}"
-              media="{{video.mediaURL|xmlSafe}}">
+              initialization="{{mpd.video.initURL|xmlSafe}}"
+              media="{{mpd.video.mediaURL|xmlSafe}}">
         {% include "segment/timeline.xml" %}
       </SegmentTemplate>
         {% endif %}
@@ -51,7 +53,7 @@
         </Representation>
       {% endfor %}
     </AdaptationSet>
-    {% for audio in audio_sets %}
+    {% for audio in mpd.audio_sets %}
     <AdaptationSet
 	id="{{ audio.id }}"
 	group="2"

--- a/templates/manifests/manifest_b.mpd
+++ b/templates/manifests/manifest_b.mpd
@@ -1,26 +1,30 @@
-<MPD type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT1.5S" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  mediaPresentationDuration="{{mediaDuration|isoDuration}}">
+<MPD type="static" xmlns="urn:mpeg:dash:schema:mpd:2011"
+     profiles="urn:mpeg:dash:profile:isoff-live:2011"
+     minBufferTime="PT1.5S"
+     xmlns:cenc="urn:mpeg:cenc:2013"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     mediaPresentationDuration="{{ mpd.mediaDuration|isoDuration }}">
  <ProgramInformation>
   <Title>{{title}}</Title>
  </ProgramInformation>
- <Period start="PT0S" duration="{{mediaDuration|isoDuration}}">
-   {% if baseURL %}<BaseURL>{{baseURL}}</BaseURL>{% endif %}
-   {%- with adp = video %}
+ <Period start="PT0S" duration="{{ mpd.mediaDuration|isoDuration }}">
+   {%- if mpd.baseURL %}<BaseURL>{{ mpd.baseURL }}</BaseURL>{%- endif %}
+   {%- with adp = mpd.video %}
      <AdaptationSet mimeType="video/mp4">
        {% include "drm/template.xml" %}
        <ContentComponent id="1" contentType="video"/>
-       {%- for rep in video.representations %}
+       {%- for rep in adp.representations %}
          <Representation id="{{rep.id}}" mimeType="video/mp4" codecs="{{rep.codecs}}" width="{{rep.width}}" height="{{rep.height}}" startWithSAP="{{rep.startWithSAP}}" bandwidth="{{rep.bitrate}}">
            <SegmentTemplate startNumber="{{ rep.start_number}}"
-                       timescale="{{video.timescale}}"
+                       timescale="{{adp.timescale}}"
                        duration="{{rep.segment_duration}}"
-                       initialization="{{video.initURL|xmlSafe}}"
-                       media="{{video.mediaURL|xmlSafe}}"/>
+                       initialization="{{adp.initURL|xmlSafe}}"
+                       media="{{adp.mediaURL|xmlSafe}}"/>
          </Representation>
        {% endfor %}
      </AdaptationSet>
    {%- endwith %}
-  {%- for adp in audio_sets %}
+  {%- for adp in mpd.audio_sets %}
   <AdaptationSet mimeType="audio/mp4" id="{{ adp.id }}">
      <ContentComponent id="1" contentType="audio" lang="eng"/>
      {% for rep in adp.representations %}

--- a/templates/manifests/manifest_e.mpd
+++ b/templates/manifests/manifest_e.mpd
@@ -1,45 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011"
-     xmlns:cenc="urn:mpeg:cenc:2013" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
-  {% if mode=='live' %}
-type="dynamic"
-  {% if minimumUpdatePeriod %}minimumUpdatePeriod="{{minimumUpdatePeriod|isoDuration}}"{% endif %}
-  {% if suggestedPresentationDelay %}suggestedPresentationDelay="{{suggestedPresentationDelay|isoDuration}}"{%endif%}
-  availabilityStartTime="{{availabilityStartTime|isoDateTime}}"
-  timeShiftBufferDepth="{{timeShiftBufferDepth|isoDuration}}"
-  {% else %}
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns="urn:mpeg:dash:schema:mpd:2011"     
+     xmlns:cenc="urn:mpeg:cenc:2013"
+     xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+{%- if mode=='live' %}
+  type="dynamic"
+  {%- if mpd.minimumUpdatePeriod %}
+    minimumUpdatePeriod="{{ mpd.minimumUpdatePeriod|isoDuration }}"
+  {%- endif %}
+  {%- if mpd.suggestedPresentationDelay %}
+  suggestedPresentationDelay="{{ mpd.suggestedPresentationDelay|isoDuration}}"
+  {%- endif %}
+  availabilityStartTime="{{ mpd.availabilityStartTime|isoDateTime}}"
+  timeShiftBufferDepth="{{ mpd.timeShiftBufferDepth|isoDuration}}"
+{% else %}
     type="static"
-  {% endif %}
-  minBufferTime="PT5.000S" maxSegmentDuration="{{maxSegmentDuration|isoDuration}}"
-  publishTime="{{publishTime|isoDateTime}}"
+{%- endif %}
+  minBufferTime="PT5.000S"
+  maxSegmentDuration="{{ mpd.maxSegmentDuration|isoDuration }}"
+  publishTime="{{ mpd.publishTime|isoDateTime }}"
   profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:dvb:dash:profile:dvbdash:2014">
- {% if baseURL %}<BaseURL>{{baseURL|xmlSafe}}</BaseURL>{% endif %}
- {% if locationURL %}<Location>{{locationURL|xmlSafe}}</Location>{% endif %}
- <Location>{{request_uri|xmlSafe}}</Location>
- {%- if timeSource %}<UTCTiming schemeIdUri="{{timeSource.method}}" value="{{timeSource.value}}"/>{% endif %}
+  {%- if mpd.baseURL %}
+  <BaseURL>{{ mpd.baseURL|xmlSafe}}</BaseURL>
+  {%- endif %}
+ {%- if mpd.locationURL %}<Location>{{
+ mpd.locationURL|xmlSafe}}</Location>
+ {%- endif %}
+ <Location>{{ request_uri|xmlSafe }}</Location>
+ {%- if mpd.timeSource %}
+ <UTCTiming schemeIdUri="{{ mpd.timeSource.method}}" value="{{mpd.timeSource.value}}"/>
+ {%- endif %}
  <Period id="0" start="PT0S"
-  {% if mode!='live' %}
-  duration="{{mediaDuration|isoDuration}}"
+  {% if mode != 'live' %}
+  duration="{{ mpd.mediaDuration|isoDuration }}"
   {% endif %}
 >
-   {%- with adp = video %}
+   {%- with adp = mpd.video %}
 <AdaptationSet
     mimeType="video/mp4"
     contentType="video"
     segmentAlignment="true"
     startWithSAP="1"
-    maxWidth="{{ video.maxWidth }}"
-    maxHeight="{{ video.maxHeight }}"
-    maxFrameRate="{{ video.maxFrameRate | frameRateFraction }}"
+    maxWidth="{{ adp.maxWidth }}"
+    maxHeight="{{ adp.maxHeight }}"
+    maxFrameRate="{{ adp.maxFrameRate | frameRateFraction }}"
     par="16:9">
         <SegmentTemplate
-            presentationTimeOffset="{{ video.presentationTimeOffset }}"
-            timescale="{{ video.timescale }}"
-            startNumber="{{ video.start_number }}"
-            initialization="{{ video.initURL|xmlSafe }}"
-            media="{{ video.mediaURL|xmlSafe }}"
-            duration="{{ video.segment_duration }}"/>
-      {% for rep in video.representations %}
+            presentationTimeOffset="{{ adp.presentationTimeOffset }}"
+            timescale="{{ adp.timescale }}"
+            startNumber="{{ adp.start_number }}"
+            initialization="{{ adp.initURL|xmlSafe }}"
+            media="{{ adp.mediaURL|xmlSafe }}"
+            duration="{{ adp.segment_duration }}"/>
+      {% for rep in adp.representations %}
       {%- if loop.first %}{% include "drm/template.xml" %}{% endif %}
       <Representation
           id="{{rep.id}}"
@@ -55,7 +68,7 @@ type="dynamic"
     {% endfor %}
     </AdaptationSet>
    {%- endwith %}
-      {% for adp in audio_sets %}
+      {% for adp in mpd.audio_sets %}
       <AdaptationSet
 	  mimeType="audio/mp4"
 	  contentType="audio"

--- a/templates/manifests/manifest_e.mpd
+++ b/templates/manifests/manifest_e.mpd
@@ -28,7 +28,7 @@
  {%- endif %}
  <Location>{{ request_uri|xmlSafe }}</Location>
  {%- if mpd.timeSource %}
- <UTCTiming schemeIdUri="{{ mpd.timeSource.method}}" value="{{mpd.timeSource.value}}"/>
+ <UTCTiming schemeIdUri="{{ mpd.timeSource.schemeIdUri}}" value="{{mpd.timeSource.value}}"/>
  {%- endif %}
  <Period id="0" start="PT0S"
   {% if mode != 'live' %}

--- a/templates/manifests/manifest_ef.mpd
+++ b/templates/manifests/manifest_ef.mpd
@@ -4,24 +4,26 @@
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      minBufferTime="PT4.00S"
      profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014"
-     publishTime="{{publishTime|isoDateTime}}"
-     {% if mode=='live' %}
+     publishTime="{{ mpd.publishTime|isoDateTime}}"
+  {%- if mode=='live' %}
      type="dynamic"
-     availabilityStartTime="{{availabilityStartTime|isoDateTime}}"
-     timeShiftBufferDepth="{{timeShiftBufferDepth|isoDuration}}"
-     {% else %}
+     availabilityStartTime="{{ mpd.availabilityStartTime|isoDateTime}}"
+     timeShiftBufferDepth="{{ mpd.timeShiftBufferDepth|isoDuration}}"
+  {% else %}
      type="static"
-     mediaPresentationDuration="{{mediaDuration|isoDuration}}"
-     {% endif %}
+     mediaPresentationDuration="{{ mpd.mediaDuration|isoDuration }}"
+  {%- endif %}
      >
- {% if baseURL %}<BaseURL>{{baseURL}}</BaseURL>{% endif %}
- <Period id="p1"
+  {%- if mpd.baseURL %}
+     <BaseURL>{{ mpd.baseURL }}</BaseURL>
+  {%- endif %}
+  <Period id="p1"
      {% if mode!='live' %}
-         duration="{{mediaDuration|isoDuration}}"
+         duration="{{ mpd.mediaDuration|isoDuration }}"
      {% endif %}
          start="PT0.000S">
 
-     {%- with adp = video %}
+     {%- with adp = mpd.video %}
        {%- for rep in adp.representations %}
          {%- if loop.first %}
            <AdaptationSet mimeType="video/mp4" codecs="{{rep.codecs}}"
@@ -38,13 +40,13 @@
           height="{{rep.height}}"
           scanType="{{rep.scanType}}">
         <SegmentTemplate startNumber="{{ rep.start_number }}" duration="{{ rep.segment_duration }}"
-         initialization="{{video.initURL|xmlSafe}}" media="{{video.mediaURL|xmlSafe}}" 
-         timescale="{{video.timescale}}"/>
+         initialization="{{adp.initURL|xmlSafe}}" media="{{adp.mediaURL|xmlSafe}}" 
+         timescale="{{adp.timescale}}"/>
       </Representation>
 	  {%- if loop.last %}</AdaptationSet>{% endif %}
       {% endfor %}
     {% endwith %}
-    {% for adp in audio_sets %}
+    {% for adp in mpd.audio_sets %}
     <AdaptationSet
 	mimeType="audio/mp4"
         codecs="{{ adp.codecs }}"

--- a/templates/manifests/manifest_h.mpd
+++ b/templates/manifests/manifest_h.mpd
@@ -19,7 +19,9 @@
   {%- if mpd.baseURL %}
      <BaseURL>{{ mpd.baseURL}}</BaseURL>
   {%- endif %}
-  <UTCTiming schemeIdUri="urn:mpeg:dash:utc:ntp:2014" value="0.europe.pool.ntp.org 1.europe.pool.ntp.org 2.europe.pool.ntp.org 3.europe.pool.ntp.org"/>
+ {%- if mpd.timeSource %}
+ <UTCTiming schemeIdUri="{{mpd.timeSource.schemeIdUri}}" value="{{mpd.timeSource.value}}"/>
+ {% endif -%}
   <Period start="PT0S" id="{{ mpd.period.id }}">
    {%- with adp = mpd.video %}
      <AdaptationSet mimeType="video/mp4" startWithSAP="{{adp.startWithSAP}}" segmentAlignment="true">

--- a/templates/manifests/manifest_h.mpd
+++ b/templates/manifests/manifest_h.mpd
@@ -4,32 +4,34 @@
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xmlns:cenc="urn:mpeg:cenc:2013"
      xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011"
-  {% if mode=='live' %}
+  {%- if mode == 'live' %}
      type="dynamic"
-     availabilityStartTime="{{availabilityStartTime|isoDateTime}}"
-     {% if minimumUpdatePeriod %}
-     minimumUpdatePeriod="{{minimumUpdatePeriod|isoDuration}}"
-     {% endif %}
-     timeShiftBufferDepth="{{timeShiftBufferDepth|isoDuration}}"
+     availabilityStartTime="{{ mpd.availabilityStartTime|isoDateTime }}"
+     {%- if mpd.minimumUpdatePeriod %}
+       minimumUpdatePeriod="{{ mpd.minimumUpdatePeriod|isoDuration }}"
+     {%- endif %}
+     timeShiftBufferDepth="{{ mpd.timeShiftBufferDepth|isoDuration }}"
   {% else %}
      type="static"
-     mediaPresentationDuration="{{mediaDuration|isoDuration}}"
-  {% endif %}
+     mediaPresentationDuration="{{ mpd.mediaDuration|isoDuration }}"
+  {%- endif %}
      minBufferTime="PT1S"  >
-     {% if baseURL %}<BaseURL>{{baseURL}}</BaseURL>{% endif %}
-   <UTCTiming schemeIdUri="urn:mpeg:dash:utc:ntp:2014" value="0.europe.pool.ntp.org 1.europe.pool.ntp.org 2.europe.pool.ntp.org 3.europe.pool.ntp.org"/>
-  <Period start="PT0S" id="{{ period.id }}">
-   {%- with adp = video %}
+  {%- if mpd.baseURL %}
+     <BaseURL>{{ mpd.baseURL}}</BaseURL>
+  {%- endif %}
+  <UTCTiming schemeIdUri="urn:mpeg:dash:utc:ntp:2014" value="0.europe.pool.ntp.org 1.europe.pool.ntp.org 2.europe.pool.ntp.org 3.europe.pool.ntp.org"/>
+  <Period start="PT0S" id="{{ mpd.period.id }}">
+   {%- with adp = mpd.video %}
      <AdaptationSet mimeType="video/mp4" startWithSAP="{{adp.startWithSAP}}" segmentAlignment="true">
        {% include "drm/template.xml" %}
        <SegmentTemplate
-                presentationTimeOffset="{{video.presentationTimeOffset}}"
-                timescale="{{video.timescale}}"
-                initialization="{{video.initURL|xmlSafe}}"
-                media="{{video.mediaURL|xmlSafe}}"
-                duration="{{ video.segment_duration }}"
-                startNumber="{{ video.start_number }}"/>
-       {%- for rep in video.representations %}
+                presentationTimeOffset="{{adp.presentationTimeOffset}}"
+                timescale="{{adp.timescale}}"
+                initialization="{{adp.initURL|xmlSafe}}"
+                media="{{adp.mediaURL|xmlSafe}}"
+                duration="{{ adp.segment_duration }}"
+                startNumber="{{ adp.start_number }}"/>
+       {%- for rep in adp.representations %}
           <Representation
               id="{{rep.id}}"
               mimeType="video/mp4"
@@ -43,7 +45,7 @@
        {%- endfor %}
      </AdaptationSet>
    {%- endwith %}
-   {%- for adp in audio_sets %}
+   {%- for adp in mpd.audio_sets %}
      <AdaptationSet
 	     mimeType="audio/mp4"
 	     lang="{{adp.language}}"

--- a/templates/manifests/manifest_i.mpd
+++ b/templates/manifests/manifest_i.mpd
@@ -4,34 +4,38 @@
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  profiles="urn:mpeg:dash:profile:isoff-live:2011"
  minBufferTime="PT9S"
-  {%- if mode=='live' %}
+  {%- if mode == 'live' %}
     type="dynamic"
-    availabilityStartTime="{{availabilityStartTime|isoDateTime}}"
-    timeShiftBufferDepth="{{timeShiftBufferDepth|isoDuration}}"
-    {% if minimumUpdatePeriod %}minimumUpdatePeriod="{{minimumUpdatePeriod|isoDuration}}"{% endif %}
+    availabilityStartTime="{{ mpd.availabilityStartTime|isoDateTime }}"
+    timeShiftBufferDepth="{{ mpd.timeShiftBufferDepth|isoDuration }}"
+    {%- if mpd.minimumUpdatePeriod %}
+      minimumUpdatePeriod="{{ mpd.minimumUpdatePeriod|isoDuration }}"
+    {%- endif %}
   {%- else %}
     type="static"
-    mediaPresentationDuration="{{mediaDuration|isoDuration}}"
+    mediaPresentationDuration="{{ mpd.mediaDuration|isoDuration }}"
   {%- endif %}
 
 >
- {%- if baseURL %}<BaseURL>{{baseURL}}</BaseURL>{% endif %}
-    <UTCTiming schemeIdUri="urn:mpeg:dash:utc:direct:2014" value="{{now|isoDateTime}}"/>
-  <Period id="{{ period.id }}">
-   {%- with adp = video %}
+{%- if mpd.baseURL %}
+<BaseURL>{{ mpd.baseURL }}</BaseURL>
+{%- endif %}
+    <UTCTiming schemeIdUri="urn:mpeg:dash:utc:direct:2014" value="{{ mpd.now|isoDateTime}}"/>
+  <Period id="{{ mpd.period.id }}">
+   {%- with adp = mpd.video %}
     <AdaptationSet
         mimeType="video/mp4"
         segmentAlignment="true"
         bitstreamSwitching="true">
       {% include "drm/template.xml" %}
       <SegmentTemplate
-            timescale="{{video.timescale}}"
-            duration="{{video.segment_duration}}"
-            initialization="{{video.initURL|xmlSafe}}"
-            media="{{video.mediaURL|xmlSafe}}"
-            startNumber="{{ video.start_number }}" >
+            timescale="{{adp.timescale}}"
+            duration="{{adp.segment_duration}}"
+            initialization="{{adp.initURL|xmlSafe}}"
+            media="{{adp.mediaURL|xmlSafe}}"
+            startNumber="{{ adp.start_number }}" >
       </SegmentTemplate>
-      {%- for rep in video.representations %}
+      {%- for rep in adp.representations %}
         <Representation
             id="{{rep.id}}"
             mimeType="video/mp4"
@@ -43,7 +47,7 @@
     {% endfor %}
     </AdaptationSet>
    {%- endwith %}
-    {%- for adp in audio_sets %}
+    {%- for adp in mpd.audio_sets %}
     <AdaptationSet
         lang="{{ adp.lang }}"
         mimeType="audio/mp4"

--- a/templates/manifests/manifest_n.mpd
+++ b/templates/manifests/manifest_n.mpd
@@ -7,26 +7,37 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="urn:mpeg:schema:mpd:2011 DASH-MPD.xsd"
     profiles="urn:mpeg:profile:isoff-live:2011"
-    publishTime="{{publishTime|isoDateTime}}"
+    publishTime="{{ mpd.publishTime|isoDateTime }}"
     minBufferTime="PT8.0S"
-  {% if mode=='live' %}
+  {% if mode == 'live' %}
     type="dynamic"
-    {% if availabilityStartTime %}availabilityStartTime="{{availabilityStartTime|isoDateTime}}"{% endif %}
-    {% if minimumUpdatePeriod %}minimumUpdatePeriod="{{minimumUpdatePeriod|isoDuration}}"{% endif %}
-    {% if timeShiftBufferDepth %}timeShiftBufferDepth="{{timeShiftBufferDepth|isoDuration}}"{% endif %}
+    {%- if mpd.availabilityStartTime %}
+    availabilityStartTime="{{ mpd.availabilityStartTime|isoDateTime }}"
+    {%- endif %}
+    {%- if mpd.minimumUpdatePeriod %}
+    minimumUpdatePeriod="{{ mpd.minimumUpdatePeriod|isoDuration}}"
+    {%- endif %}
+    {%- if mpd.timeShiftBufferDepth %}
+    timeShiftBufferDepth="{{ mpd.timeShiftBufferDepth|isoDuration }}"
+    {%- endif %}
   {% else %}
     type="static"
-    mediaPresentationDuration="{{mediaDuration|isoDuration}}"
-  {% endif %}
-    >
+    mediaPresentationDuration="{{ mpd.mediaDuration|isoDuration }}"
+  {%- endif %}
+  >
+  {%- with period = mpd.period %}
     <Period
-     start="{{period.start|isoDuration}}"
-     id="{{period.id}}"
-     {% if period.duration %}duration="{{period.duration|isoDuration}}"{% endif %}
+     start="{{ period.start|isoDuration}}"
+     id="{{ period.id}}"
+     {%- if period.duration %}
+     duration="{{period.duration|isoDuration}}"
+     {%- endif %}
     >
-    {% if baseURL %}<BaseURL>{{baseURL}}</BaseURL>{% endif %}
+    {%- if mpd.baseURL %}
+    <BaseURL>{{ mpd.baseURL }}</BaseURL>
+    {%- endif %}
     {% include "events/period.xml" %}
-   {%- with adp = video %}
+   {%- with adp = period.video_track %}
     <AdaptationSet
         mimeType="video/mp4"
         par="16:9"
@@ -34,13 +45,13 @@
         startWithSAP="1">
         {% include "events/adaptationset.xml" %}
         {% include "drm/template.xml" %}
-      {%- for rep in video.representations %}
+      {%- for rep in adp.representations %}
         {%- if loop.first %}
           <SegmentTemplate
-              initialization="{{video.initURL|xmlSafe}}"
-              media="{{video.mediaURL|xmlSafe}}"
-              presentationTimeOffset="{{video.presentationTimeOffset}}"
-              timescale="{{video.timescale}}"
+              initialization="{{adp.initURL|xmlSafe}}"
+              media="{{adp.mediaURL|xmlSafe}}"
+              presentationTimeOffset="{{adp.presentationTimeOffset}}"
+              timescale="{{adp.timescale}}"
               >
             {% include "segment/timeline.xml" %}
           </SegmentTemplate>
@@ -58,7 +69,7 @@
       {% endfor %}
     </AdaptationSet>
    {%- endwith %}
-  {%- for adp in audio_sets %}
+  {%- for adp in mpd.audio_sets %}
       <AdaptationSet
           lang="{{ adp.lang }}"
 	  id="{{ adp.id }}"
@@ -87,5 +98,6 @@
       {%- endfor %}
       </AdaptationSet>
   {%- endfor %}
-  </Period>
+</Period>
+{%- endwith %}
 </MPD>

--- a/templates/manifests/manifest_vod_aiv.mpd
+++ b/templates/manifests/manifest_vod_aiv.mpd
@@ -2,17 +2,17 @@
 <MPD
     xmlns="urn:mpeg:dash:schema:mpd:2011"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    mediaPresentationDuration="{{mediaDuration|isoDuration}}"
     minBufferTime="PT10S"
     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011"
     type="static"
     xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+    mediaPresentationDuration="{{ mpd.mediaDuration|isoDuration }}"
 >
-{% for period in periods %}
+{% for period in mpd.periods %}
   <Period
       id="{{period.id}}"
       start="{{period.start|isoDuration}}"
-      duration="{{mediaDuration|isoDuration}}">
+      duration="{{ mpd.mediaDuration|isoDuration }}">
       {% for adp in period.adaptationSets %}
       <AdaptationSet
         mimeType="{{adp.mimeType}}"
@@ -48,8 +48,8 @@
         {%- if adp.content_type == "audio" %}
           <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
         {% endif %}
-        {%- if baseURL %}
-          <BaseURL>{{baseURL|xmlSafe}}{{rep.id|xmlSafe}}.{{adp.fileSuffix}}</BaseURL>
+        {%- if mpd.baseURL %}
+          <BaseURL>{{ mpd.baseURL|xmlSafe }}{{rep.id|xmlSafe}}.{{adp.fileSuffix}}</BaseURL>
         {%- else %}
           <BaseURL>{{url_for('dash-od-media', stream=stream.directory,
           filename=rep.id, ext=adp.fileSuffix)|xmlSafe}}</BaseURL>

--- a/templates/patches/hand_made.xml
+++ b/templates/patches/hand_made.xml
@@ -3,14 +3,14 @@
     xmlns="urn:mpeg:dash:schema:mpd-patch:2020"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="urn:mpeg:dash:schema:mpd-patch:2020 DASH-MPD-PATCH.xsd"
-    mpdId="{{ mpd_id }}"
+    mpdId="{{ mpd.mpd_id }}"
     originalPublishTime="{{ original_publish_time|isoDateTime }}"
-    publishTime="{{ publishTime|isoDateTime }}">
-  <replace sel="/MPD/@publishTime">{{ publishTime|isoDateTime }}</replace>
+    publishTime="{{ mpd.publishTime|isoDateTime }}">
+  <replace sel="/MPD/@publishTime">{{ mpd.publishTime|isoDateTime }}</replace>
   <replace sel="/MPD/PatchLocation[1]">
-    <PatchLocation ttl="{{ patch.ttl }}">{{ patch.location }}</PatchLocation>
+    <PatchLocation ttl="{{ mpd.patch.ttl }}">{{ mpd.patch.location }}</PatchLocation>
   </replace>
-  {%- for period in periods %}
+  {%- for period in mpd.periods %}
     {%- for adp in period.adaptationSets %}
       {%- if adp.representations %}
         {%- with rep=adp.representations[0] %}

--- a/tests/fixtures/hand_made_live_enc.mpd
+++ b/tests/fixtures/hand_made_live_enc.mpd
@@ -3,8 +3,8 @@
   <ProgramInformation>
     <Title>Big Buck Bunny</Title>
   </ProgramInformation>
-  <Location>http://unit.test/dash/live/fixtures/hand_made.mpd?drm=all&amp;start=today&amp;time=xsd</Location>
-  <UTCTiming schemeIdUri="urn:mpeg:dash:utc:http-xsdate:2014" value="http://unit.test/time/xsd"/>
+  <Location>http://unit.test/dash/live/fixtures/hand_made.mpd?drm=all&amp;start=today&amp;time=http-ntp</Location>
+  <UTCTiming schemeIdUri="urn:mpeg:dash:utc:http-ntp:2014" value="http://unit.test/time/http-ntp"/>
   <Period start="PT0S" id="p0">
     <BaseURL>http://unit.test/dash/live/fixtures/</BaseURL>
     <AdaptationSet mimeType="video/mp4" contentType="video" segmentAlignment="true" startWithSAP="1" maxWidth="1920" maxHeight="1080" maxFrameRate="24" par="16:9">

--- a/tests/fixtures/manifest_h_vod.mpd
+++ b/tests/fixtures/manifest_h_vod.mpd
@@ -10,7 +10,6 @@
   
      minBufferTime="PT1S"  >
      <BaseURL>http://unit.test/dash/vod/fixtures/</BaseURL>
-   <UTCTiming schemeIdUri="urn:mpeg:dash:utc:ntp:2014" value="0.europe.pool.ntp.org 1.europe.pool.ntp.org 2.europe.pool.ntp.org 3.europe.pool.ntp.org"/>
   <Period start="PT0S" id="p0">
      <AdaptationSet mimeType="video/mp4" startWithSAP="1" segmentAlignment="true">
        

--- a/tests/mixins/check_manifest.py
+++ b/tests/mixins/check_manifest.py
@@ -40,6 +40,7 @@ from dashlive.server.options.container import OptionsContainer
 from dashlive.server.options.dash_option import DashOption
 from dashlive.server.options.utc_time_options import UTCMethod
 from dashlive.server.options.repository import OptionsRepository
+from dashlive.server.requesthandler.base import TemplateContext
 from dashlive.server.requesthandler.manifest_context import ManifestContext
 from dashlive.server.requesthandler.manifest_requests import ServeManifest
 
@@ -365,11 +366,16 @@ class DashManifestCheckMixin:
             stream: models.Stream,
             options: OptionsContainer) -> dict:
         mock = MockServeManifest(flask.request)
-        context = ManifestContext(
-            manifest=manifests.manifest[mpd_filename], options=options,
-            stream=stream).to_dict()
-        context['remote_addr'] = mock.request.remote_addr
-        context['request_uri'] = mock.request.url
+        context: TemplateContext = {
+            'mpd': ManifestContext(
+                manifest=manifests.manifest[mpd_filename], options=options,
+                stream=stream),
+            'mode': mode,
+            'options': options,
+            'title': stream.title,
+            'remote_addr': mock.request.remote_addr,
+            'request_uri': mock.request.url,
+        }
         return context
 
     @staticmethod

--- a/tests/mixins/check_manifest.py
+++ b/tests/mixins/check_manifest.py
@@ -269,8 +269,10 @@ class DashManifestCheckMixin:
                 http_client=self.async_client, mode=mode, pool=pool,
                 duration=duration, url=mpd_url,
                 encrypted=encrypted, debug=debug, check_media=check_media)
-            await dv.load(data=response.get_data(as_text=False))
-            while not dv.finished() and timeout > 0:
+            loaded = await dv.load(data=response.get_data(as_text=False))
+            if not loaded:
+                print(response.get_data(as_text=True))
+            while loaded and not dv.finished() and timeout > 0:
                 await dv.validate()
                 if dv.has_errors():
                     break

--- a/tests/mixins/check_manifest.py
+++ b/tests/mixins/check_manifest.py
@@ -40,6 +40,7 @@ from dashlive.server.options.container import OptionsContainer
 from dashlive.server.options.dash_option import DashOption
 from dashlive.server.options.utc_time_options import UTCMethod
 from dashlive.server.options.repository import OptionsRepository
+from dashlive.server.requesthandler.manifest_context import ManifestContext
 from dashlive.server.requesthandler.manifest_requests import ServeManifest
 
 from .mock_time import MockTime
@@ -362,20 +363,11 @@ class DashManifestCheckMixin:
             stream: models.Stream,
             options: OptionsContainer) -> dict:
         mock = MockServeManifest(flask.request)
-        context = mock.calculate_manifest_params(
-            mpd_name=mpd_filename, options=options)
-        if options.encrypted:
-            kids = set()
-            for period in context['periods']:
-                kids.update(period.key_ids())
-            if not kids:
-                keys = models.Key.all_as_dict()
-            else:
-                keys = models.Key.get_kids(kids)
-            context["DRM"] = mock.generate_drm_dict(stream, keys, options)
+        context = ManifestContext(
+            manifest=manifests.manifest[mpd_filename], options=options,
+            stream=stream).to_dict()
         context['remote_addr'] = mock.request.remote_addr
         context['request_uri'] = mock.request.url
-        context['title'] = stream.title
         return context
 
     @staticmethod

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,6 +32,7 @@ from bs4 import BeautifulSoup
 import flask
 
 from dashlive.server import models
+from dashlive.server.requesthandler.streams import ViewStreamAjaxResponse
 from dashlive.utils.date_time import to_iso_datetime
 
 from .mixins.flask_base import FlaskTestBase
@@ -630,8 +631,9 @@ class TestRestApi(FlaskTestBase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         if ajax:
-            upload_url = response.json['upload_url']
-            csrf_token = response.json['csrf_tokens']['upload']
+            vsap: ViewStreamAjaxResponse = response.json
+            upload_url = vsap['upload_url']
+            csrf_token = vsap['csrf_tokens']['upload']
             content_type = "multipart/form-data"
         else:
             html = BeautifulSoup(response.text, 'lxml')

--- a/tests/test_cgi_options.py
+++ b/tests/test_cgi_options.py
@@ -231,6 +231,7 @@ class TestServerOptions(TestCaseMixin, unittest.TestCase):
             'leeway': 16,
             'mainAudio': None,
             'mode': 'vod',
+            'ntpSources': [],
             'manifestErrors': [],
             'mainText': None,
             'marlin': {
@@ -344,7 +345,7 @@ class TestServerOptions(TestCaseMixin, unittest.TestCase):
         opts.remove_unused_parameters('vod')
         for field in {
                 'availabilityStartTime', 'minimumUpdatePeriod', 'timeShiftBufferDepth',
-                'utcMethod', 'utcValue'}:
+                'ntpSources', 'utcMethod', 'utcValue'}:
             del expected[field]
         self.maxDiff = None
         self.assertDictEqual(expected, opts.toJSON())
@@ -405,6 +406,7 @@ class TestServerOptions(TestCaseMixin, unittest.TestCase):
             },
             "minimumUpdatePeriod": None,
             "mode": "vod",
+            'ntpSources': [],
             "numPeriods": None,
             "patch": False,
             "ping": {

--- a/tests/test_cgi_options.py
+++ b/tests/test_cgi_options.py
@@ -1,5 +1,6 @@
 import unittest
 
+from dashlive.drm.location import DrmLocation
 from dashlive.server.options.drm_options import DrmSelection
 from dashlive.server.options.container import OptionsContainer
 from dashlive.server.options.repository import OptionsRepository
@@ -95,7 +96,7 @@ class TestServerOptions(TestCaseMixin, unittest.TestCase):
             'availabilityStartTime': 'epoch',
             'bugCompatibility': ['saio'],
             'clockDrift': 20,
-            'drmSelection': [('playready', {'pro', 'moov', 'cenc'})],
+            'drmSelection': [('playready', set(DrmLocation.all()))],
             'minimumUpdatePeriod': None,
             'numPeriods': 2,
             'playready': {
@@ -180,31 +181,32 @@ class TestServerOptions(TestCaseMixin, unittest.TestCase):
                 msg=f'Expected {key} to be "{value}" but found "{actual}"')
 
     def test_drm_locations(self) -> None:
+        all_locations: set[DrmLocation] = set(DrmLocation.all())
         self.assertEqual(
             DrmSelection.from_string('marlin'),
-            [('marlin', {'pro', 'moov', 'cenc'})])
+            [('marlin', all_locations)])
         self.assertEqual(
             DrmSelection.from_string('MARLIN'),
-            [('marlin', {'pro', 'moov', 'cenc'})])
+            [('marlin', all_locations)])
         self.assertEqual(
             DrmSelection.from_string('ClearKey'),
-            [('clearkey', {'pro', 'moov', 'cenc'})])
+            [('clearkey', all_locations)])
         self.assertEqual(
             DrmSelection.from_string('playready,marlin'),
-            [('playready', {'pro', 'moov', 'cenc'}), ('marlin', {'pro', 'moov', 'cenc'})])
+            [('playready', all_locations), ('marlin', all_locations)])
         self.assertEqual(
             DrmSelection.from_string('all'),
             [
-                ('clearkey', {'pro', 'moov', 'cenc'}),
-                ('marlin', {'pro', 'moov', 'cenc'}),
-                ('playready', {'pro', 'moov', 'cenc'})
+                ('clearkey', all_locations),
+                ('marlin', all_locations),
+                ('playready', all_locations)
             ])
         self.assertEqual(
             DrmSelection.from_string('all-cenc-moov'),
             [
-                ('clearkey', {'cenc', 'moov'}),
-                ('marlin', {'cenc', 'moov'}),
-                ('playready', {'cenc', 'moov'})
+                ('clearkey', {DrmLocation.CENC, DrmLocation.MOOV}),
+                ('marlin', {DrmLocation.CENC, DrmLocation.MOOV}),
+                ('playready', {DrmLocation.CENC, DrmLocation.MOOV})
             ])
 
     @MockTime("2023-04-05T06:30:00Z")

--- a/tests/test_cgi_options.py
+++ b/tests/test_cgi_options.py
@@ -345,7 +345,7 @@ class TestServerOptions(TestCaseMixin, unittest.TestCase):
         opts.remove_unused_parameters('vod')
         for field in {
                 'availabilityStartTime', 'minimumUpdatePeriod', 'timeShiftBufferDepth',
-                'ntpSources', 'utcMethod', 'utcValue'}:
+                'patch', 'ntpSources', 'utcMethod', 'utcValue'}:
             del expected[field]
         self.maxDiff = None
         self.assertDictEqual(expected, opts.toJSON())

--- a/tests/test_hand_made_manifest.py
+++ b/tests/test_hand_made_manifest.py
@@ -161,7 +161,7 @@ class HandMadeManifestTests(FlaskTestBase, DashManifestCheckMixin):
         self.check_generated_manifest_against_fixture(
             'hand_made.mpd', mode='live', drm='all', encrypted=True,
             now="2022-09-06T15:10:00Z",
-            acodec='mp4a', time='xsd', start='today')
+            acodec='mp4a', time='http-ntp', start='today')
 
     async def test_manifest_patch_live(self):
         await self.check_manifest_patch_live(False)

--- a/tests/test_hand_made_manifest.py
+++ b/tests/test_hand_made_manifest.py
@@ -24,9 +24,9 @@ import unittest
 
 import flask
 
+from dashlive.drm.system import DrmSystem
 from dashlive.server import models
 from dashlive.server.options.repository import OptionsRepository
-from dashlive.server.options.drm_options import ALL_DRM_TYPES
 from dashlive.utils import objects
 
 from .mixins.check_manifest import DashManifestCheckMixin
@@ -186,7 +186,7 @@ class HandMadeManifestTests(FlaskTestBase, DashManifestCheckMixin):
             manifest='hand_made.mpd',
             mode='live',
             stream=self.FIXTURES_PATH.name)
-        drm_checks = ['none'] + ALL_DRM_TYPES
+        drm_checks = ['none'] + DrmSystem.values()
         for drm in drm_checks:
             args['drm'] = drm
             options = OptionsRepository.convert_cgi_options(args, defaults=defaults)

--- a/tests/test_manifest_h.py
+++ b/tests/test_manifest_h.py
@@ -40,6 +40,7 @@ class ManifestHTest(FlaskTestBase, DashManifestCheckMixin):
     def test_generated_manifest_against_fixture_live(self):
         self.check_generated_manifest_against_fixture(
             'manifest_h.mpd', mode='live', acodec='mp4a', encrypted=False,
+            time='ntp', ntp_servers='europe-ntp',
             now="2023-09-10T17:56:43Z")
 
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -25,6 +25,7 @@ import logging
 from pathlib import Path
 import shutil
 import unittest
+from unittest.mock import patch
 
 import flask
 
@@ -149,7 +150,7 @@ class TestPopulateDatabase(FlaskTestBase):
         tmpdir = self.create_upload_folder()
         with self.app.app_context():
             self.app.config['BLOB_FOLDER'] = tmpdir
-        with unittest.mock.patch('requests.Session') as mock:
+        with patch('requests.Session') as mock:
             mock.return_value = ClientHttpSession(self.client)
             dashlive.upload.main(args)
         self.check_database_results(jsonfile, 2)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -34,7 +34,7 @@ from dashlive.drm.clearkey import ClearKey
 from dashlive.mpeg.dash.validator import ConcurrentWorkerPool
 from dashlive.server import manifests, models
 from dashlive.server.requesthandler.base import RequestHandlerBase
-from dashlive.server.options.drm_options import DrmLocation, PlayreadyVersion
+from dashlive.server.options.drm_options import DrmLocationOption, PlayreadyVersion
 from dashlive.utils.date_time import UTC, to_iso_datetime, from_isodatetime
 from dashlive.utils.objects import dict_to_cgi_params, flatten
 
@@ -258,7 +258,7 @@ class TestHandlers(DashManifestCheckMixin, FlaskTestBase):
         filename = 'hand_made.mpd'
         drm_options = ['drm=all', 'drm=marlin']
         # add all combinations of PlayReady options
-        for choice in DrmLocation.cgi_choices:
+        for choice in DrmLocationOption.cgi_choices:
             if choice[1] is None:
                 drm_options.append('drm=playready')
                 continue
@@ -269,7 +269,7 @@ class TestHandlers(DashManifestCheckMixin, FlaskTestBase):
                 if float(version) < 2.0 and choice[1] != 'pro':
                     continue
                 drm_options.append(f'drm=playready-{choice[1]}&playready_version={version}')
-        for choice in DrmLocation.cgi_choices:
+        for choice in DrmLocationOption.cgi_choices:
             if choice[1] is None:
                 drm_options.append('drm=clearkey')
                 continue

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -139,7 +139,9 @@ class TestHandlers(DashManifestCheckMixin, FlaskTestBase):
                         duration=int(self.MEDIA_DURATION // 3))
                     await dv.load(data=response.get_data(as_text=False))
                     await dv.validate()
-                self.assertFalse(dv.has_errors())
+                if dv.has_errors():
+                    dv.print_manifest_text()
+                self.assertFalse(dv.has_errors(), 'Validation failed')
                 today = from_isodatetime(now).replace(
                     hour=0, minute=0, second=0, microsecond=0)
                 start_time = from_isodatetime(start)
@@ -234,9 +236,10 @@ class TestHandlers(DashManifestCheckMixin, FlaskTestBase):
                 await mpd.validate()
             if mpd.has_errors():
                 print(mpd_url)
+                mpd.print_manifest_text()
                 for err in mpd.get_errors():
                     print(err)
-            self.assertFalse(mpd.has_errors())
+            self.assertFalse(mpd.has_errors(), 'DASH validation failed')
             head = self.client.head(mpd_url)
             msg = r'Expected HEAD.contentLength={} == GET.contentLength={} for URL {}'.format(
                 head.headers['Content-Length'], response.headers['Content-Length'],


### PR DESCRIPTION
This PR removes the logic from the request handler base class that generated the context used for servicing DASH requests. The code is moved into a new ManifestContext class. This simplifies the request hander base class and allows type hints to be defined for the data passed into the templates for rendering  manifest templates.

A typed dictionary is used to the context dictionary that is passed to the Jinja renderer to provide additional type hints.