### PR TITLE
Fix code scanning alert no. 49: Reflected server-side cross-site scripting

### DIFF
--- a/dashlive/server/requesthandler/keypairs.py
+++ b/dashlive/server/requesthandler/keypairs.py
@@ -19,6 +19,7 @@
 #  Author              :    Alex Ashley
 #
 #############################################################################
+import logging
 
 import flask
 
@@ -183,7 +184,8 @@ class DeleteKeyHandler(HTMLHandlerBase):
         try:
             self.check_csrf('keys', flask.request.form)
         except (ValueError, CsrfFailureException) as err:
-            return flask.make_response(f'CSRF failure: {err}', 400)
+            logging.warning('CSRF failure: %s', err)
+            return flask.make_response('CSRF failure', 400)
         models.db.session.delete(current_keypair)
         models.db.session.commit()
         flask.flash(f'Deleted keypair {current_keypair.hkid}', 'success')
@@ -197,7 +199,8 @@ class DeleteKeyHandler(HTMLHandlerBase):
         try:
             self.check_csrf('keys', flask.request.args)
         except (ValueError, CsrfFailureException) as err:
-            return jsonify({'error': f'CSRF failure: {err}'}, 400)
+            logging.warning('CSRF failure: %s', err)
+            return jsonify({'error': 'CSRF failure'}, 400)
         result = {
             "deleted": current_keypair.KID.hex,
         }

--- a/dashlive/server/requesthandler/manifest_requests.py
+++ b/dashlive/server/requesthandler/manifest_requests.py
@@ -177,7 +177,7 @@ class LegacyManifestUrl(ServeManifest):
             return flask.redirect(url)
         except KeyError:
             logging.debug('Unknown manifest: %s', manifest)
-            return flask.make_response(f'{manifest} not found', 404)
+            return flask.make_response(f'{html.escape(manifest)} not found', 404)
 
 class ServePatch(RequestHandlerBase):
     """

--- a/dashlive/server/requesthandler/user_management.py
+++ b/dashlive/server/requesthandler/user_management.py
@@ -21,6 +21,7 @@
 #############################################################################
 
 import datetime
+import logging
 
 import flask
 from flask_login import current_user, login_user, logout_user
@@ -185,7 +186,8 @@ class EditUser(HTMLHandlerBase):
         try:
             self.check_csrf('users', flask.request.form)
         except (ValueError, CsrfFailureException) as err:
-            return flask.make_response({'error': f'CSRF failure: {err}'}, 400)
+            logging.error('CSRF failure: %s', err)
+            return flask.make_response({'error': 'CSRF failure occurred'}, 400)
         user = self.get_model()
         if not current_user.is_admin and user.pk != current_user.pk:
             flask.flash('Only an admin user can modify other users', 'error')


### PR DESCRIPTION
Fixes [https://github.com/asrashley/dash-live/security/code-scanning/49](https://github.com/asrashley/dash-live/security/code-scanning/49)

To fix the reflected XSS vulnerability, we need to escape the user-provided `manifest` variable before including it in the response. The `html.escape()` function from the standard library can be used to escape special characters in the `manifest` string, making it safe to include in the response.

- **General Fix:** Escape the `manifest` variable using `html.escape()` before including it in the response.
- **Detailed Fix:** Modify the line where the `manifest` variable is used in the f-string to include `html.escape(manifest)`.
- **Specific Changes:** Update line 180 in the file `dashlive/server/requesthandler/manifest_requests.py` to use `html.escape(manifest)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
