### PR TITLE
upgrade sqlalchemy to 2.0.36 and flask-sqlalchemy to v3.1.1

### DIFF
--- a/dashlive/drm/base.py
+++ b/dashlive/drm/base.py
@@ -24,7 +24,7 @@ from abc import ABC, abstractmethod
 from typing import AbstractSet, NamedTuple, Protocol
 
 from dashlive.mpeg.mp4 import BoxWithChildren, ContentProtectionSpecificBox
-from dashlive.server.models import Stream
+from dashlive.server.models.stream import Stream
 from dashlive.server.options.container import OptionsContainer
 
 from .key_tuple import KeyTuple

--- a/dashlive/drm/playready.py
+++ b/dashlive/drm/playready.py
@@ -37,7 +37,7 @@ from Crypto.Hash import SHA256
 from flask import render_template
 
 from dashlive.mpeg import mp4
-from dashlive.server.models import Stream
+from dashlive.server.models.stream import Stream
 from dashlive.server.options.container import OptionsContainer
 from dashlive.utils.buffered_reader import BufferedReader
 

--- a/dashlive/server/models/adaptation_set.py
+++ b/dashlive/server/models/adaptation_set.py
@@ -12,10 +12,11 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dashlive.mpeg.dash.content_role import ContentRole
 
+from .base import Base
 from .content_type import ContentType
 from .db import db
-from .mediafile import MediaFile
 from .mixin import ModelMixin
+from .mediafile import MediaFile
 from .type_decorators import IntEnumType
 
 if TYPE_CHECKING:
@@ -31,7 +32,7 @@ class AdaptationSetJson(TypedDict):
     encrypted: bool
     lang: str | None
 
-class AdaptationSet(db.Model, ModelMixin):
+class AdaptationSet(ModelMixin["AdaptationSet"], Base):
     __plural__ = 'AdaptationSets'
     __tablename__ = "adaptation_set"
 

--- a/dashlive/server/models/all.py
+++ b/dashlive/server/models/all.py
@@ -1,11 +1,9 @@
 from .error_reason import ErrorReason
-from .group import Group
 from .content_type import ContentType
 from .blob import Blob
-from .key import Key, KeyMaterial
-from .token import Token, TokenType
+from .key import Key
+from .token import Token
 from .user import User
-
 from .adaptation_set import AdaptationSet
 from .mediafile import MediaFile
 from .mediafile_error import MediaFileError
@@ -14,8 +12,10 @@ from .period import Period
 from .multi_period_stream import MultiPeriodStream
 from .db import db
 
-__all__ = [
-    "db", "AdaptationSet", "Blob", "ContentType", "ErrorReason",
-    "Group", "Key", "KeyMaterial", "MediaFile", "MediaFileError",
-    "MultiPeriodStream", "Period", "Stream", "Token", "TokenType", "User"
+models = [
+    AdaptationSet, Blob, ErrorReason, ContentType, Key, MediaFile,
+    MediaFileError, MultiPeriodStream, Period, Stream, Token, User,
 ]
+
+def create_all_tables() -> None:
+    db.create_all()

--- a/dashlive/server/models/base.py
+++ b/dashlive/server/models/base.py
@@ -1,0 +1,4 @@
+from sqlalchemy.orm import DeclarativeBase
+
+class Base(DeclarativeBase):
+    pass

--- a/dashlive/server/models/blob.py
+++ b/dashlive/server/models/blob.py
@@ -6,38 +6,41 @@
 #
 #############################################################################
 import contextlib
+from datetime import datetime
 from io import SEEK_SET
-from typing import cast, AbstractSet
 from pathlib import Path
+from typing import cast, AbstractSet, TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy.orm import relationship  # type: ignore
+from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from dashlive.utils.date_time import to_iso_datetime
 from dashlive.utils.json_object import JsonObject
 
-from .db import db
+from .base import Base
 from .mixin import ModelMixin
 
-class Blob(ModelMixin, db.Model):
+if TYPE_CHECKING:
+    from .mediafile import MediaFile
+
+class Blob(ModelMixin["Blob"], Base):
     """
     Database model for a generic file store
     """
     __plural__ = 'Blobs'
     __tablename__ = 'Blob'
 
-    pk = sa.Column('pk', sa.Integer, primary_key=True)
-    filename = sa.Column(sa.String, unique=True, nullable=False)
-    created = sa.Column(
-        'created',
+    pk: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
+    filename: Mapped[str] = mapped_column(sa.String, unique=True, nullable=False)
+    created: Mapped[datetime] = mapped_column(
         sa.DateTime(timezone=True),
         nullable=False,
         server_default=sa.func.now())
-    size = sa.Column(sa.Integer, nullable=False)
-    sha1_hash = sa.Column(sa.String(42), nullable=False)
-    content_type = sa.Column(sa.String(64), nullable=False)
-    auto_delete = sa.Column(sa.Boolean, default=True, nullable=False)
-    mediafile = relationship("MediaFile", back_populates="blob")
+    size: Mapped[int] = mapped_column(sa.Integer, nullable=False)
+    sha1_hash: Mapped[str] = mapped_column(sa.String(42), nullable=False)
+    content_type: Mapped[str] = mapped_column(sa.String(64), nullable=False)
+    auto_delete: Mapped[bool] = mapped_column(sa.Boolean, default=True, nullable=False)
+    mediafile: Mapped["MediaFile"] = relationship("MediaFile", back_populates="blob")
 
     @classmethod
     def all(cls) -> list["Blob"]:

--- a/dashlive/server/models/content_type.py
+++ b/dashlive/server/models/content_type.py
@@ -5,26 +5,24 @@
 #  Author              :    Alex Ashley
 #
 #############################################################################
-from typing import ClassVar, Optional, cast, TYPE_CHECKING
+from typing import Optional, cast, TYPE_CHECKING
 
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from .db import db
+from .base import Base
 from .mixin import ModelMixin
 from .session import DatabaseSession
 
 if TYPE_CHECKING:
     from .adaptation_set import AdaptationSet
 
-
-class ContentType(db.Model, ModelMixin):
+class ContentType(ModelMixin["ContentType"], Base):
     """
     Table for holding RFC 6838 content types
     """
-
-    __plural__: ClassVar[str] = "ContentTypes"
-    __tablename__: ClassVar[str] = "content_type"
+    __plural__: str = 'ContentTypes'
+    __tablename__: str = "content_type"
 
     pk: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
@@ -39,10 +37,10 @@ class ContentType(db.Model, ModelMixin):
         return cast(Optional[ContentType], cls.get_one(session=session, **kwargs))
 
     @classmethod
-    def populate_if_empty(cls) -> None:
+    def populate_if_empty(cls, session: DatabaseSession) -> None:
         count: int = cls.count()
         if count > 0:
             return
         for name in ["application", "video", "audio", "text", "image"]:
             ct = ContentType(name=name)
-            db.session.add(ct)
+            session.add(ct)

--- a/dashlive/server/models/db.py
+++ b/dashlive/server/models/db.py
@@ -1,3 +1,5 @@
 from flask_sqlalchemy import SQLAlchemy
 
-db = SQLAlchemy()
+from .base import Base
+
+db = SQLAlchemy(model_class=Base)

--- a/dashlive/server/models/key.py
+++ b/dashlive/server/models/key.py
@@ -1,29 +1,29 @@
-import re
-from typing import cast, AbstractSet, Optional
+from typing import cast, AbstractSet, ClassVar, Optional, TYPE_CHECKING
 
 import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from dashlive.drm.keymaterial import KeyMaterial
 from dashlive.utils.json_object import JsonObject
 
+from .base import Base
 from .db import db
-from .mediafile_keys import mediafile_keys
 from .mixin import ModelMixin
+from .mediafile_keys import mediafile_keys
 
-def kid_validator(prop, value):
-    if not re.match(r'^[0-9a-f-]+$', value, re.IGNORECASE):
-        raise TypeError(f'Expected a hex value, not {value:s}')
-    return value.replace('-', '').lower()
+if TYPE_CHECKING:
+    from .mediafile import MediaFile
 
-class Key(db.Model, ModelMixin):
-    __plural__ = 'Keys'
+class Key(ModelMixin["Key"], Base):
+    __plural__: ClassVar[str] = 'Keys'
+    __tablename__: ClassVar[str] = 'key'
 
-    pk = sa.Column(sa.Integer, primary_key=True)
-    hkid = sa.Column(sa.String(34), nullable=False, unique=True, index=True)
-    hkey = sa.Column(sa.String(34), nullable=False)
-    computed = sa.Column(sa.Boolean, nullable=False)
-    halg = sa.Column(sa.String(16), nullable=True)
-    mediafiles: db.Mapped[list["MediaFile"]] = db.relationship(  # noqa: F821
+    pk: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
+    hkid: Mapped[str] = mapped_column(sa.String(34), nullable=False, unique=True, index=True)
+    hkey: Mapped[str] = mapped_column(sa.String(34), nullable=False)
+    computed: Mapped[bool] = mapped_column(sa.Boolean, nullable=False)
+    halg: Mapped[str] = mapped_column(sa.String(16), nullable=True)
+    mediafiles: Mapped[list["MediaFile"]] = relationship(  # noqa: F821
         secondary=mediafile_keys, back_populates='encryption_keys')
 
     @property

--- a/dashlive/server/models/mediafile_error.py
+++ b/dashlive/server/models/mediafile_error.py
@@ -5,18 +5,23 @@
 #  Author              :    Alex Ashley
 #
 #############################################################################
+from typing import ClassVar, TYPE_CHECKING
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from .db import db
+from .base import Base
 from .error_reason import ErrorReason
 from .mixin import ModelMixin
 from .type_decorators import IntEnumType
 
-class MediaFileError(db.Model, ModelMixin):
-    __plural__ = 'MediaFileErrors'
+if TYPE_CHECKING:
+    from .mediafile import MediaFile
 
-    pk: Mapped[int] = sa.Column('pk', sa.Integer, primary_key=True)
+class MediaFileError(ModelMixin["MediaFileError"], Base):
+    __plural__: ClassVar[str] = 'MediaFileErrors'
+    __tablename__: ClassVar[str] = 'media_file_error'
+
+    pk: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
     reason: Mapped[ErrorReason] = mapped_column(IntEnumType(ErrorReason), nullable=False)
     details: Mapped[str] = mapped_column(sa.String(200), nullable=False)
     media_pk: Mapped[int] = mapped_column(sa.ForeignKey('media_file.pk'))

--- a/dashlive/server/models/mediafile_keys.py
+++ b/dashlive/server/models/mediafile_keys.py
@@ -1,7 +1,10 @@
-from .db import db
+from sqlalchemy import Table, Column, ForeignKey
 
-mediafile_keys = db.Table(
+from .base import Base
+
+mediafile_keys = Table(
     "mediafile_keys",
-    db.Column("media_pk", db.ForeignKey("media_file.pk"), primary_key=True),
-    db.Column("key_pk", db.ForeignKey("key.pk"), primary_key=True),
+    Base.metadata,
+    Column("media_pk", ForeignKey("media_file.pk"), primary_key=True),
+    Column("key_pk", ForeignKey("key.pk"), primary_key=True),
 )

--- a/dashlive/server/models/mixin.py
+++ b/dashlive/server/models/mixin.py
@@ -1,23 +1,24 @@
-from typing import AbstractSet, Iterable, Optional
+from typing import AbstractSet, Generic, Iterable, Optional, TypeVar
 
 from sqlalchemy import Column
-from sqlalchemy.orm import class_mapper, ColumnProperty, RelationshipProperty  # type: ignore
-from sqlalchemy.orm.dynamic import AppenderQuery  # type: ignore
+from sqlalchemy.orm import class_mapper, ColumnProperty, RelationshipProperty
+from sqlalchemy.orm.dynamic import AppenderQuery
 
 from dashlive.utils.json_object import JsonObject
 
 from .db import db
 from .session import DatabaseSession
 
-class ModelMixin:
+T = TypeVar('T')
+class ModelMixin(Generic[T]):
     """
-    Common utility functions to add to all models
+    Mixin that adds some common helper functions to a model
     """
 
     @classmethod
     def get_all(cls,
                 session: DatabaseSession | None = None,
-                order_by: list[Column] | None = None) -> Iterable["ModelMixin"]:
+                order_by: list[Column] | None = None) -> Iterable[T]:
         """
         Return all items from this table
         """
@@ -31,7 +32,7 @@ class ModelMixin:
     @classmethod
     def get_one(cls,
                 session: DatabaseSession | None = None,
-                **kwargs) -> Optional["ModelMixin"]:
+                **kwargs) -> Optional[T]:
         """
         Get one object from a model, or None if not found
         """
@@ -44,7 +45,7 @@ class ModelMixin:
     def search(clz, max_items: int | None = None,
                order_by: list[Column] | None = None,
                session: DatabaseSession | None = None,
-               **kwargs) -> list[db.Model]:
+               **kwargs) -> Iterable[T]:
         query = db.select(clz)
         if kwargs:
             query = query.filter_by(**kwargs)
@@ -113,7 +114,7 @@ class ModelMixin:
         if commit:
             db.session.commit()
 
-    def delete(self, commit=False) -> None:
+    def delete(self, commit: bool = False) -> None:
         db.session.delete(self)
         if commit:
             db.session.commit()

--- a/dashlive/server/models/multi_period_stream.py
+++ b/dashlive/server/models/multi_period_stream.py
@@ -14,15 +14,16 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 import sqlalchemy_jsonfield  # type: ignore
 
 from dashlive.server.options.form_input_field import FormInputContext
+from dashlive.utils.json_object import JsonObject
 
-from .db import db
+from .base import Base
 from .mixin import ModelMixin
 from .session import DatabaseSession
 
 if TYPE_CHECKING:
     from .period import Period
 
-class MultiPeriodStream(db.Model, ModelMixin):
+class MultiPeriodStream(ModelMixin["MultiPeriodStream"], Base):
     __ALLOWED_NAME_CHARS = r'A-Za-z0-9_.\-'
     __tablename__ = "mp_stream"
     __plural__ = 'MultiPeriodStreams'
@@ -33,7 +34,7 @@ class MultiPeriodStream(db.Model, ModelMixin):
     title: Mapped[str] = mapped_column(sa.String(120), nullable=False)
     periods: Mapped[list["Period"]] = relationship(
         back_populates='parent', order_by='Period.ordering', cascade="all, delete")
-    options = sa.Column(
+    options: Mapped[JsonObject | None] = mapped_column(
         'options',
         sqlalchemy_jsonfield.JSONField(
             enforce_string=True,
@@ -90,7 +91,7 @@ class MultiPeriodStream(db.Model, ModelMixin):
         Return all items from this table
         """
         return cast(
-            Iterable[cls], cls.get_all(session=session, order_by=order_by))
+            Iterable[MultiPeriodStream], cls.get_all(session=session, order_by=order_by))
 
     @classmethod
     def validate_values(cls,

--- a/dashlive/server/models/session.py
+++ b/dashlive/server/models/session.py
@@ -1,15 +1,17 @@
 """
 Interface definition for a database session
 """
-
 from typing import Protocol
+from sqlalchemy.sql.expression import Executable
+from sqlalchemy.engine import Result
+from .base import Base
 
 class DatabaseSession(Protocol):
     """
     Interface to abstract away from sqlalchemy session
     """
 
-    def add(self, model) -> None:
+    def add(self, model: Base) -> None:
         """Add item to database"""
 
     def commit(self) -> None:
@@ -18,13 +20,16 @@ class DatabaseSession(Protocol):
     def close(self) -> None:
         """Close database session"""
 
-    def delete(self, model) -> None:
+    def delete(self, model: Base) -> None:
         """Remove item from database"""
+
+    def execute(self, statement: Executable) -> Result:
+        """Execute a raw SQL statement"""
 
     def flush(self) -> None:
         """Flush changes to database, but can still be rolled back"""
 
-    def query(self, *args):
+    def query(self, *args) -> Executable:
         """start database query"""
 
     def rollback(self) -> None:

--- a/dashlive/server/models/stream.py
+++ b/dashlive/server/models/stream.py
@@ -9,11 +9,11 @@ import datetime
 import hashlib
 import logging
 from pathlib import Path
-from typing import cast, AbstractSet, Optional, NamedTuple
+from typing import cast, AbstractSet, ClassVar, Optional, NamedTuple
 
 import flask
 import sqlalchemy as sa
-from sqlalchemy.orm import relationship  # type: ignore
+from sqlalchemy.orm import relationship, Mapped, mapped_column
 import sqlalchemy_jsonfield  # type: ignore
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
@@ -22,16 +22,15 @@ from dashlive.utils.json_object import JsonObject
 from dashlive.utils.string import str_or_none
 from dashlive.mpeg.dash.reference import StreamTimingReference
 
+from .base import Base
 from .blob import Blob
 from .db import db
 from .mediafile import MediaFile
 from .mixin import ModelMixin
 
-
 class TrackSummary(NamedTuple):
     content_type: str
     count: int
-
 
 class StreamTrackSummary(NamedTuple):
     video: TrackSummary
@@ -39,27 +38,27 @@ class StreamTrackSummary(NamedTuple):
     text: TrackSummary
 
 
-class Stream(db.Model, ModelMixin):
+class Stream(ModelMixin["Stream"], Base):
     """
     Model for each media stream
     """
-    __plural__ = 'Streams'
-    __tablename__ = 'Stream'
+    __plural__: ClassVar[str] = 'Streams'
+    __tablename__: ClassVar[str] = 'Stream'
 
-    pk = sa.Column(sa.Integer, primary_key=True)
-    title = sa.Column(sa.String(120))
-    directory = sa.Column(sa.String(32), unique=True, index=True)
-    marlin_la_url = sa.Column(sa.String(), nullable=True)
-    playready_la_url = sa.Column(sa.String(), nullable=True)
-    media_files = relationship('MediaFile', cascade="all, delete")
-    timing_ref = sa.Column(
+    pk: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
+    title: Mapped[str] = mapped_column(sa.String(120))
+    directory: Mapped[str] = mapped_column(sa.String(32), unique=True, index=True)
+    marlin_la_url: Mapped[str | None] = mapped_column(sa.String(), nullable=True)
+    playready_la_url: Mapped[str | None] = mapped_column(sa.String(), nullable=True)
+    media_files: Mapped[list[MediaFile]] = relationship('MediaFile', cascade="all, delete")
+    timing_ref: Mapped[JsonObject | None] = mapped_column(
         'timing_reference',
         sqlalchemy_jsonfield.JSONField(
             enforce_string=True,
             enforce_unicode=False
         ),
         nullable=True)
-    defaults = sa.Column(
+    defaults: Mapped[JsonObject | None] = mapped_column(
         'defaults',
         sqlalchemy_jsonfield.JSONField(
             enforce_string=True,

--- a/dashlive/server/options/form_input_field.py
+++ b/dashlive/server/options/form_input_field.py
@@ -1,34 +1,39 @@
-from typing import Any, NamedTuple, TypedDict
+from typing import Any, NamedTuple, NotRequired, TypedDict
 
 class FieldOption(NamedTuple):
     title: str
     value: str | int
     selected: bool
 
+class ColumnClassNames(NamedTuple):
+    left: str
+    middle: str
+    right: str
+
 class FormInputContext(TypedDict):
-    columns: tuple[str, str, str]
-    className: str
-    datalist_type: str
-    disabled: bool
-    error: str
-    featured: bool
-    href: str
-    link_title: str
-    max: int
-    min: int
-    maxlength: int
-    minlength: int
-    multiple: bool
+    columns: NotRequired[ColumnClassNames]
+    className: NotRequired[str]
+    datalist_type: NotRequired[str]
+    disabled: NotRequired[bool]
+    error: NotRequired[str]
+    featured: NotRequired[bool]
+    href: NotRequired[str]
+    link_title: NotRequired[str]
+    max: NotRequired[int]
+    min: NotRequired[int]
+    maxlength: NotRequired[int]
+    minlength: NotRequired[int]
+    multiple: NotRequired[bool]
     name: str
-    options: list[FieldOption]
-    pattern: str
-    placeholder: str
-    prefix: str
-    required: bool
-    rowClass: str
-    spellcheck: bool
-    step: int
-    title: str
-    text: str
+    options: NotRequired[list[FieldOption]]
+    pattern: NotRequired[str]
+    placeholder: NotRequired[str]
+    prefix: NotRequired[str]
+    required: NotRequired[bool]
+    rowClass: NotRequired[str]
+    spellcheck: NotRequired[bool]
+    step: NotRequired[int]
+    title: NotRequired[str]
+    text: NotRequired[str]
     type: str  # 'checkbox', 'datalist', 'number', 'select', 'radio', 'link', 'hidden'
     value: Any

--- a/dashlive/server/requesthandler/csrf.py
+++ b/dashlive/server/requesthandler/csrf.py
@@ -33,7 +33,7 @@ import urllib.parse
 import flask  # type: ignore
 
 from dashlive.server.models.token import Token, TokenType, KEY_LIFETIMES
-from dashlive.server.models.db import db
+from dashlive.server.models import db
 from dashlive.utils.json_object import JsonObject
 
 from .exceptions import CsrfFailureException

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4==4.8.0
 coverage==7.3.0
+mypy==1.13.0
 pytest==7.4.0
 pytest-xdist==3.3.1
 pyinstrument==4.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 crccheck==1.1
 Flask==2.3.3
 Flask-SocketIO==5.3.6
-Flask-SQLAlchemy==3.0.3
+Flask-SQLAlchemy==3.1.1
 flask_jwt_extended==4.6.0
 flask-login==0.6.3
 idna==3.7
@@ -29,7 +29,7 @@ python-socketio==5.9.0
 requests==2.32.0
 six==1.16.0
 soupsieve==2.4.1
-SQLAlchemy==2.0.16
+SQLAlchemy==2.0.36
 SQLAlchemy-JSONField==1.0.1.post0
 typing_extensions==4.6.3
 urllib3==1.26.19

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ deps =
     -rrequirements.txt
     -rdev-requirements.txt
     flake8==6.0.0
-    mypy==0.991
+    mypy==1.13.0
 
-setenv = 
+setenv =
     MYPYPATH = {toxinidir}/stubs
     CI = 1
 


### PR DESCRIPTION
as part of the upgrade, the database models needed to be updated to use the latest ORM mapping style. This has the advantage of providing correct type hints for every field in the model.