### PR TITLE
upgrade pyfakefs to v5.9.1

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.8.0
 coverage==7.3.0
 flake8==7.2.0
 mypy==1.13.0
-pyfakefs==5.7.3
+pyfakefs==5.9.1
 pytest==7.4.0
 pytest-xdist==3.3.1
 pyinstrument==4.6.1


### PR DESCRIPTION
some of the Python unit tests are unreliable due to race condition issues when using the pyfakefs library.