### PR TITLE
Bump lxml from 4.9.2 to 6.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Jinja2==3.1.6
 langcodes==3.4.0
 language-data==1.2.0
 lesscpy==0.15.1
-lxml==4.9.2
+lxml==6.0.0
 MarkupSafe==2.1.3
 marisa-trie==1.2.0
 mock==3.0.5


### PR DESCRIPTION
the version of lxml being used was over 2 years old and is no longer available as pre-compiled wheels on the Windows platform.