### PR TITLE
correct path to virtual env after moving to uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,13 @@ If using Linux:
 
 ```sh
 uv sync
-. ./virtenv/bin/activate
+. ./.venv/bin/activate
 ```
 
 or Windows:
 
 ```powershell
 uv sync
-.\virtenv\Scripts\activate
 ```
 
 Install JavaScript libraries:
@@ -108,7 +107,7 @@ To start the server:
 or if using Windows:
 
 ```powershell
-runserver.ps1
+.\runserver.ps1
 ```
 
 It will start an HTTP server on port 5000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [project]
 name = "dash-live"
-version = "0.1.0"
-description = "Add your description here"
+version = "3.6.0"
+description = "A simulated MPEG DASH service"
 readme = "README.md"
 requires-python = ">=3.11"
+license = { file = "LICENSE" }
 dependencies = [
     "alembic==1.16.4",
     "asgiref==3.8.1",
@@ -59,6 +60,10 @@ dev = [
     "tox>=4.28.4",
     "tox-uv>=1.28.0",
 ]
+
+[project.urls]
+Issues = "https://github.com/asrashley/dash-live/issues"
+Repository = "https://github.com/asrashley/dash-live.git"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/runserver.ps1
+++ b/runserver.ps1
@@ -4,6 +4,6 @@ $Env:FLASK_APP = "dashlive.server.app"
 $Env:SERVER_NAME = $Env:COMPUTERNAME
 $Env:SERVER_PORT = "5000"
 
-npm run legacy-css
-npm run main-css
-python -m flask --app dashlive.server.app run --host=0.0.0.0 --debug
+npm run all-css
+npm run build
+uv run flask --app dashlive.server.app run --host=0.0.0.0 --debug

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "dash-live"
-version = "0.1.0"
+version = "3.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
uv creates a .venv directory for the virtual env, rather than a virtenv directory. The startup script and documentation needed to be updated.