### PR TITLE
Set channel layout when encoding audio

### DIFF
--- a/dashlive/media/create/create.py
+++ b/dashlive/media/create/create.py
@@ -140,6 +140,7 @@ class DashMediaCreator:
             self, source: Path, info: AudioStreamInfo, file_index: int, track_id: int) -> None:
         available_codecs: set[str] = {a.codecString for a in AUDIO_PROFILES.values()}
         codec: str = info.codec
+        layout: str = info.channel_layout
         if self.options.audio_codec:
             codec = self.options.audio_codec
         channels: int = info.channels
@@ -151,9 +152,12 @@ class DashMediaCreator:
         if codec not in available_codecs:
             if channels > 2:
                 codec = AUDIO_PROFILES[AudioProfile.SURROUND].codecString
+                if layout == 'stereo':
+                    AUDIO_PROFILES[AudioProfile.SURROUND].layout
             else:
                 codec = AUDIO_PROFILES[AudioProfile.STEREO].codecString
-        params = AudioEncodingParameters(codecString=codec, bitrate=audio_bitrate, channels=channels)
+        params = AudioEncodingParameters(
+            codecString=codec, bitrate=audio_bitrate, channels=channels, layout=layout)
         self.pending_tasks.append(AudioEncodingTask(
             options=self.options, source=source, file_index=file_index,
             track_id=track_id, params=params, info=info))

--- a/dashlive/media/create/encoding_parameters.py
+++ b/dashlive/media/create/encoding_parameters.py
@@ -19,6 +19,7 @@ class AudioEncodingParameters(NamedTuple):
     bitrate: int
     codecString: str
     channels: int
+    layout: str
 
 
 UHD_8BIT_BITRATE_LADDER: list[VideoEncodingParameters] = [
@@ -110,6 +111,10 @@ BITRATE_PROFILES: dict[BitrateProfiles, list[VideoEncodingParameters]] = {
 }
 
 AUDIO_PROFILES: dict[AudioProfile, AudioEncodingParameters] = {
-    AudioProfile.STEREO: AudioEncodingParameters(bitrate=96, codecString='aac', channels=2),
-    AudioProfile.SURROUND: AudioEncodingParameters(bitrate=320, codecString='eac3', channels=6),
+    AudioProfile.STEREO: AudioEncodingParameters(
+        bitrate=96, codecString='aac', channels=2, layout='stereo',
+    ),
+    AudioProfile.SURROUND: AudioEncodingParameters(
+        bitrate=320, codecString='eac3', channels=6, layout='5.1',
+    ),
 }

--- a/dashlive/media/create/ffmpeg_helper.py
+++ b/dashlive/media/create/ffmpeg_helper.py
@@ -93,7 +93,6 @@ class AudioStreamInfo(StreamInfoBase):
             channels=info.get("channels", 2),
             channel_layout=info.get("channel_layout", "stereo")
         )
-        asi.channel_layout = asi.channel_layout.replace(r'(side)', '')
         if asi.codec == 'ac3':
             asi.codec = 'eac3'
         return asi

--- a/dashlive/mpeg/mp4.py
+++ b/dashlive/mpeg/mp4.py
@@ -2019,12 +2019,19 @@ class EAC3SpecificBox(Mp4Atom):
     }
     OBJECT_FIELDS.update(Mp4Atom.OBJECT_FIELDS)
 
+    substreams: list[EAC3SubStream]
+    data_rate: int
+    flag_ec3_extension_type_a: bool = False
+    complexity_index_type_a: int | None = None
+
     @classmethod
-    def parse(clz, src, parent, **kwargs):
-        rv = Mp4Atom.parse(src, parent, **kwargs)
-        r = BitsFieldReader(clz.classname(), src, rv, size=None)
+    def parse(clz, src, parent, **kwargs) -> dict[str, Any] | None:
+        rv: dict[str, Any] | None = Mp4Atom.parse(src, parent, **kwargs)
+        if rv is None:
+            return None
+        r: BitsFieldReader = BitsFieldReader(clz.classname(), src, rv, size=None)
         r.read(13, "data_rate")
-        num_ind_sub = r.get(3, "num_ind_sub") + 1
+        num_ind_sub: int = r.get(3, "num_ind_sub") + 1
         rv["substreams"] = []
         for i in range(num_ind_sub):
             r2 = r.duplicate("EAC3SubStream", {})
@@ -2036,9 +2043,9 @@ class EAC3SpecificBox(Mp4Atom):
             r.read(8, 'complexity_index_type_a')
         return rv
 
-    def encode_fields(self, dest):
+    def encode_fields(self, dest) -> None:
         ba = bitstring.BitArray()
-        num_ind_sub = len(self.substreams)
+        num_ind_sub: int = len(self.substreams)
         ba.append(bitstring.pack('uint:13, uint:3', self.data_rate,
                                  num_ind_sub - 1))
         for s in self.substreams:
@@ -2052,8 +2059,8 @@ class EAC3SpecificBox(Mp4Atom):
 
 @fourcc('dac3')
 class AC3SpecificBox(Mp4Atom):
-    SAMPLE_RATES = [48000, 44100, 32000, 0]
-    CHANNEL_CONFIGURATIONS = [
+    SAMPLE_RATES: ClassVar[list[int]] = [48000, 44100, 32000, 0]
+    CHANNEL_CONFIGURATIONS: ClassVar[list[tuple[int, str]]] = [
         (2, "1 + 1 (Ch1, Ch2)"),
         (1, "1/0 (C)"),
         (2, "2/0 (L, R)"),

--- a/tests/test_create_media.py
+++ b/tests/test_create_media.py
@@ -161,6 +161,7 @@ class MockMediaTools(TestCaseMixin):
                     '-codec:a:0': 'eac3',
                     '-ac:a:0': '6',
                     '-b:a:0': '320k',
+                    '-af': 'channelmap=channel_layout=5.1(side)',
                 })
         except ValueError:
             pass
@@ -330,6 +331,12 @@ class MockMediaTools(TestCaseMixin):
                 "channels": 6,
                 "channel_layout": "5.1(side)",
             })
+        elif self.options.audio_channels == 6:
+            result['streams'][1].update({
+                "channels": 6,
+                "channel_layout": "5.1(side)",
+            })
+
         result['format']['format_name'] = src_file.suffix[1:]
         return json.dumps(result)
 
@@ -546,7 +553,7 @@ class TestMediaCreation(TestCase):
             profile=None,
             sample_rate=48000,
             channels=6,
-            channel_layout="5.1")
+            channel_layout="5.1(side)")
         self.maxDiff = None
         self.assertEqual(expected, info)
 


### PR DESCRIPTION
When creating multi-channel audio tracks, ffmpeg needs to be told how to map the audio tracks into the output streams. For example, to specifiy a stream has 5.1 audio, rather than 6 independent channels.

fixes #99 
